### PR TITLE
Add build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 A curated collection of articles, books, podcasts, podcast episodes, and other resources which offer a more complete understanding of Bitcoin. Available for everyone at [bitcoin-resources.com](https://bitcoin-resources.com).
 
+### Contribute
+
 If you find any typos, grammatical errors, broken links, or any other mistakes or issues, please point them out to me on [twitter](https://twitter.com/dergigi). Or create a pull request to correct them.
+
+For more details on how to contribute please refer to the [contribution guidelines](https://github.com/bitcoin-resources/bitcoin-resources.github.io/blob/master/CONTRIBUTING.md).
 
 ---
 
-Created with :heart: by Gigi. 
+Created with :heart: by Gigi.
 
 [![tippin.me](https://badgen.net/badge/%E2%9A%A1%EF%B8%8Ftippin.me/@dergigi/F0918E)](https://tippin.me/@dergigi)

--- a/README.md
+++ b/README.md
@@ -10,11 +10,20 @@ For more details on how to contribute please refer to the [contribution guidelin
 
 ### Build the site locally
 
+Prerequisites:
+
 1. Install [Jekyll](https://jekyllrb.com/docs/installation/)
 2. Clone the repository and `cd` into the site's directory
-3. Run `npm run gulp` to build assets
-4. Run `bundle exec jekyll serve` to build the site
-5. Visit `localhost:4000` to view the site
+3. Run `npm install` to install dependencies from `package.json`
+4. Run `bundle install` to install dependencies from `Gemfile`
+
+Building the site:
+
+1. Run `npm run gulp` to build assets
+2. Run `bundle exec jekyll serve` to build the site
+3. Visit `localhost:4000` to view the site
+
+You might have to install `gulp` globally, which you can do with `npm install --global gulp-cli`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ If you find any typos, grammatical errors, broken links, or any other mistakes o
 
 For more details on how to contribute please refer to the [contribution guidelines](https://github.com/bitcoin-resources/bitcoin-resources.github.io/blob/master/CONTRIBUTING.md).
 
+### Build the site locally
+
+1. Install [Jekyll](https://jekyllrb.com/docs/installation/)
+2. Clone the repository and `cd` into the site's directory
+3. Run `npm run gulp` to build assets
+4. Run `bundle exec jekyll serve` to build the site
+5. Visit `localhost:4000` to view the site
+
 ---
 
 Created with :heart: by Gigi.


### PR DESCRIPTION
Added how to build the site locally:

1. Install [Jekyll](https://jekyllrb.com/docs/installation/)
2. Clone the repository and `cd` into the site's directory
3. Run `npm run gulp` to build assets
4. Run `bundle exec jekyll serve` to build the site
5. Visit `localhost:4000` to view the site