### PR TITLE
Add audio versions to articles

### DIFF
--- a/_includes/articles.html
+++ b/_includes/articles.html
@@ -3,6 +3,9 @@
 <ul class="articles">
 {% for article in sorted_articles %}
   <li>
+    {% if article.audio %}
+    <a href="{{ article.audio }}" target="_blank" title="Audio version">🎧</a>
+    {% endif %}
     <a href="{{ article.link }}" target="_blank">{{ article.title }}</a> by {{ article.author }}
   </li>
 {% endfor %}

--- a/collections/_articles/a-cypherpunks-manifesto.md
+++ b/collections/_articles/a-cypherpunks-manifesto.md
@@ -6,4 +6,5 @@ link: https://www.activism.net/cypherpunk/manifesto.html
 category: Cypherpunks
 date: Mar 9, 1993
 lesson: 20
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_163---A-Cypherpunks-Manifesto-Eric-Hughes-e2ndpc
 ---

--- a/collections/_articles/amostpeacefulrevolution.md
+++ b/collections/_articles/amostpeacefulrevolution.md
@@ -6,4 +6,5 @@ link: https://medium.com/@nic__carter/a-most-peaceful-revolution-8b63b64c203e
 category: A Social Revolution
 date: Sep 7, 2019
 lesson: 6
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_293---A-Most-Peaceful-Revolution-Nic-Carter-e5bfpm/a-an7otc
 ---

--- a/collections/_articles/an-open-letterto-banksabout-bitcoinand-cryptocurrencies.md
+++ b/collections/_articles/an-open-letterto-banksabout-bitcoinand-cryptocurrencies.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/an-open-letter-to-banks-about-bitcoin-and-cryptocur
 category: Misc
 date: Mar 4, 2018
 lesson: 
+audio: 
 ---

--- a/collections/_articles/bitcoin-bootsonthe-ground-venezuela.md
+++ b/collections/_articles/bitcoin-bootsonthe-ground-venezuela.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2019/11/21/bitcoin-boots-on-the-ground-venezuela/
 category: Through the Looking Glass
 date: Nov 21, 2019
 lesson: 9
+audio: 
 ---

--- a/collections/_articles/bitcoin-cannot-be-banned.md
+++ b/collections/_articles/bitcoin-cannot-be-banned.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-cannot-be-banned/
 category: Who Controls Bitcoin?
 date: Nov 8, 2019
 lesson: 6
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_356---Bitcoin-Cannot-be-Banned-Parker-Lewis-eb05gd/a-a1i88ov
 ---

--- a/collections/_articles/bitcoin-cant-be-copied.md
+++ b/collections/_articles/bitcoin-cant-be-copied.md
@@ -6,4 +6,5 @@ link: https://www.unchained-capital.com/blog/bitcoin-cant-be-copied/
 category: Bitcoin's Identity
 date: Aug 2, 2019
 lesson: 2
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_291---Bitcoin-Cant-Be-Copied-Parker-Lewis-e58g11/a-amgcud
 ---

--- a/collections/_articles/bitcoin-does-not-waste-energy.md
+++ b/collections/_articles/bitcoin-does-not-waste-energy.md
@@ -6,4 +6,5 @@ link: https://www.unchained-capital.com/blog/bitcoin-does-not-waste-energy/
 category: Proof-of-work
 date: Aug 16, 2019
 lesson: 17
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_306---Bitcoin-Does-Not-Waste-Energy-Parker-Lewis-e7ojph/a-at0dnn
 ---

--- a/collections/_articles/bitcoin-doesnt-waste-electricity.md
+++ b/collections/_articles/bitcoin-doesnt-waste-electricity.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/bitcoin-doesnt-waste-electricity-649694ea3605
 category: Proof-of-work
 date: Mar 30, 2017
 lesson: 17
+audio: 
 ---

--- a/collections/_articles/bitcoin-fixes-this.md
+++ b/collections/_articles/bitcoin-fixes-this.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-fixes-this/
 category: Misc
 date: Aug 30, 2019
 lesson: 12
+audio: 
 ---

--- a/collections/_articles/bitcoin-governance.md
+++ b/collections/_articles/bitcoin-governance.md
@@ -6,4 +6,5 @@ link: https://medium.com/@pierre_rochard/bitcoin-governance-37e86299470f
 category: Who Controls Bitcoin?
 date: Jul 9, 2018
 lesson: 
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_108---Bitcoin-Governance-Pierre-Rochard-e2ndr8/a-a7d61b
 ---

--- a/collections/_articles/bitcoin-has-no-intrinsic-valueand-thats-great.md
+++ b/collections/_articles/bitcoin-has-no-intrinsic-valueand-thats-great.md
@@ -6,4 +6,5 @@ link: https://medium.com/coinmonks/bitcoin-has-no-intrinsic-value-and-thats-grea
 category: Bitcoin's Uniqueness
 date: May 8, 2019
 lesson: 10
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_249---Bitcoin-Has-No-Intrinsic-Value---Thats-Great--Conner-Brown-e43bcm
 ---

--- a/collections/_articles/bitcoin-is-not-backed-by-nothing.md
+++ b/collections/_articles/bitcoin-is-not-backed-by-nothing.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-is-not-backed-by-nothing/
 category: Bitcoin's Uniqueness
 date: Sep 27, 2019
 lesson: 10
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_335---Bitcoin-is-Not-Backed-by-Nothing-Parker-Lewis-e9v1rs/a-a18o11t
 ---

--- a/collections/_articles/bitcoin-is-not-for-criminals.md
+++ b/collections/_articles/bitcoin-is-not-for-criminals.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-is-not-for-criminals/
 category: Misc
 date: Nov 29, 2019
 lesson: 
+audio: 
 ---

--- a/collections/_articles/bitcoin-is-not-too-slow.md
+++ b/collections/_articles/bitcoin-is-not-too-slow.md
@@ -6,4 +6,5 @@ link: https://www.unchained-capital.com/blog/bitcoin-is-not-too-slow/
 category: Bitcoin's Identity
 date: Aug 23, 2019
 lesson: 18
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_321---Bitcoin-is-Not-Too-Slow-Parker-Lewis-e93sbj/a-a12atfo
 ---

--- a/collections/_articles/bitcoin-is-not-too-volatile.md
+++ b/collections/_articles/bitcoin-is-not-too-volatile.md
@@ -6,4 +6,5 @@ link: https://www.unchained-capital.com/blog/bitcoin-is-not-too-volatile/
 category: Bitcoin's Identity
 date: Aug 9, 2019
 lesson: 10
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_302---Bitcoin-is-Not-Too-Volatile-Parker-Lewis-e6diss/a-aqp0ht
 ---

--- a/collections/_articles/bitcoin-is-nota-pyramid-scheme.md
+++ b/collections/_articles/bitcoin-is-nota-pyramid-scheme.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-is-not-a-pyramid-scheme/
 category: Bitcoin's Identity
 date: Oct 18, 2019
 lesson: 
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_351---Bitcoin-is-Not-a-Pyramid-Scheme--Parker-Lewis-eapakf/a-a1emvh4
 ---

--- a/collections/_articles/bitcoin-isa-rally-cry.md
+++ b/collections/_articles/bitcoin-isa-rally-cry.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-is-a-rally-cry/
 category: A Social Revolution
 date: Mar 26, 2020
 lesson: 12
+audio: https://anchor.fm/thecryptoconomy/episodes/Read_371---Bitcoin-is-a-Rally-Cry-Parker-Lewis-ec1io2/a-a1poq6j
 ---

--- a/collections/_articles/bitcoin-miners-beware-invalid-blocks-need-not-apply.md
+++ b/collections/_articles/bitcoin-miners-beware-invalid-blocks-need-not-apply.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/bitcoin-miners-beware-invalid-blocks-need-not-apply
 category: Who Controls Bitcoin?
 date: Jun 1, 2018
 lesson: 
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_283---Invalid-Blocks-Need-Not-Apply-StopAndDecrypt-e4uu7j/a-akrfpv
 ---

--- a/collections/_articles/bitcoin-not-blockchain.md
+++ b/collections/_articles/bitcoin-not-blockchain.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-not-blockchain/
 category: Bitcoin's Uniqueness
 date: Sep 6, 2019
 lesson: 21
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_329---Bitcoin--Not-Blockchain-Parker-Lewis-e9h0cv/a-a15nml1
 ---

--- a/collections/_articles/bitcoin-obsoletes-all-other-money.md
+++ b/collections/_articles/bitcoin-obsoletes-all-other-money.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-obsoletes-all-other-money/
 category: Money
 date: Jan 24, 2020
 lesson: 12
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_345---Bitcoin-Obsoletes-All-Other-Money--Parker-Lewis-eahce1/a-a1cm4bc
 ---

--- a/collections/_articles/bitcoin-pastand-future.md
+++ b/collections/_articles/bitcoin-pastand-future.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/bitcoin-past-and-future-f2feba1f419d
 category: Bitcoin's Identity
 date: May 30, 2018
 lesson: 
+audio: 
 ---

--- a/collections/_articles/bitcoin-wikis-privacy-aritcle.md
+++ b/collections/_articles/bitcoin-wikis-privacy-aritcle.md
@@ -6,4 +6,5 @@ link: https://en.bitcoin.it/wiki/Privacy
 category: Privacy
 date: Feb 22, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/bitcoinand-privacy.md
+++ b/collections/_articles/bitcoinand-privacy.md
@@ -6,4 +6,5 @@ link: https://www.youtube.com/watch?v=UDydB3z-6Y0
 category: Privacy
 date: Jun 29, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/bitcoinis-andthatisenough.md
+++ b/collections/_articles/bitcoinis-andthatisenough.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/bitcoin-is-and-that-is-enough-e3116870eed1
 category: Bitcoin's Identity
 date: Feb 20, 2017
 lesson: 
+audio: 
 ---

--- a/collections/_articles/bitcoinis-common-sense.md
+++ b/collections/_articles/bitcoinis-common-sense.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/bitcoin-is-common-sense/
 category: Money
 date: May 1, 2020
 lesson: 14
+audio: 
 ---

--- a/collections/_articles/bitcoinis-worseis-better.md
+++ b/collections/_articles/bitcoinis-worseis-better.md
@@ -6,4 +6,5 @@ link: https://www.gwern.net/Bitcoin-is-Worse-is-Better
 category: Bitcoin's Uniqueness
 date: May 27, 2011
 lesson: 
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_327---Bitcoin-is-Worse-is-Better-gwern-e9e9iv
 ---

--- a/collections/_articles/bitcoinisa-decentralized-organism.md
+++ b/collections/_articles/bitcoinisa-decentralized-organism.md
@@ -6,4 +6,5 @@ link: https://medium.com/@BrandonQuittem/bitcoin-is-a-decentralized-organism-myc
 category: Bitcoin as a Living Organism
 date: Dec 11, 2018
 lesson: 1
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_201---Bitcoin-is-a-Decentralized-Organism---Mycelium-Part-1---Brandon-Quittem-e2sarg/a-a8dkgo
 ---

--- a/collections/_articles/bitcoinisa-social-creature.md
+++ b/collections/_articles/bitcoinisa-social-creature.md
@@ -6,4 +6,5 @@ link: https://medium.com/@BrandonQuittem/bitcoin-is-a-social-creature-mushroom-p
 category: Bitcoin as a Living Organism
 date: Dec 28, 2018
 lesson: 1
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_224---Bitcoin-is-a-Social-Creature--Mycelium-Part-2-Brandon-Quittem-e3iq3u/a-acc8oj
 ---

--- a/collections/_articles/bitcoins-energy-consumption-ashiftinperspective.md
+++ b/collections/_articles/bitcoins-energy-consumption-ashiftinperspective.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2018/06/10/bitcoin-s-energy-consumption/
 category: Through the Looking Glass
 date: Jun 10, 2018
 lesson: 17
+audio: 
 ---

--- a/collections/_articles/bitcoins-eternal-struggle-how-bitcoin-thrivesonthe-edgebetween-orderand-chaos.md
+++ b/collections/_articles/bitcoins-eternal-struggle-how-bitcoin-thrivesonthe-edgebetween-orderand-chaos.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2019/12/22/bitcoin-s-eternal-struggle/
 category: Through the Looking Glass
 date: Dec 22, 2019
 lesson: 7
+audio: 
 ---

--- a/collections/_articles/bitcoins-gravity-howideavaluefeedbackloopsarepullingpeoplein.md
+++ b/collections/_articles/bitcoins-gravity-howideavaluefeedbackloopsarepullingpeoplein.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2018/06/10/bitcoin-s-energy-consumption/
 category: Through the Looking Glass
 date: Jun 10, 2018
 lesson: 1
+audio: 
 ---

--- a/collections/_articles/bitcoins-habitats-how-bitcoinissurvivingandthrivingbetweenworlds.md
+++ b/collections/_articles/bitcoins-habitats-how-bitcoinissurvivingandthrivingbetweenworlds.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2020/03/01/bitcoin-s-habitats/
 category: Through the Looking Glass
 date: Mar 1, 2020
 lesson: 6
+audio: 
 ---

--- a/collections/_articles/bitcoinsdistributionwasfair.md
+++ b/collections/_articles/bitcoinsdistributionwasfair.md
@@ -6,4 +6,5 @@ link: https://blog.picks.co/bitcoins-distribution-was-fair-e2ef7bbbc892
 category: Bitcoin's Uniqueness
 date: Oct 4, 2018
 lesson: 14
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_172---Bitcoins-Distribution-Was-Fair-Dan-Held-e2ndp0/a-a7d5uv
 ---

--- a/collections/_articles/blockchain-proofof-work-isa-decentralized-clock.md
+++ b/collections/_articles/blockchain-proofof-work-isa-decentralized-clock.md
@@ -6,4 +6,5 @@ link: https://grisha.org/blog/2018/01/23/explaining-proof-of-work/
 category: Proof-of-work
 date: Jan 23, 2018
 lesson: 17
+audio: 
 ---

--- a/collections/_articles/catallaxytheoriginsof-bitcoininnovationandspontaneousorder.md
+++ b/collections/_articles/catallaxytheoriginsof-bitcoininnovationandspontaneousorder.md
@@ -6,4 +6,5 @@ link: https://medium.com/@francispouliot/catallaxy-the-origins-of-bitcoin-and-in
 category: A Social Revolution
 date: Sep 19, 2017
 lesson: 5
+audio: 
 ---

--- a/collections/_articles/cryptosovereignty.md
+++ b/collections/_articles/cryptosovereignty.md
@@ -6,4 +6,5 @@ link: https://cryptosovereignty.org/cryptosovereignty/
 category: A Social Revolution
 date: Feb 3, 2019
 lesson: 
+audio: 
 ---

--- a/collections/_articles/da-os-democracyand-governance.md
+++ b/collections/_articles/da-os-democracyand-governance.md
@@ -6,4 +6,5 @@ link: https://alcor.org/cryonics/Cryonics2016-4.pdf#page=28
 category: Lesson Links
 date: May 31, 2016
 lesson: 1
+audio: 
 ---

--- a/collections/_articles/dandelionsanda-bright-futurefor-bitcoin-privacy.md
+++ b/collections/_articles/dandelionsanda-bright-futurefor-bitcoin-privacy.md
@@ -6,4 +6,5 @@ link: https://medium.com/@thecryptoconomy/dandelions-and-a-bright-future-for-bit
 category: Privacy
 date: Jun 27, 2018
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/dear-bitcoiners-anoptimisticlettertofriendsandfoesaroundtheglobe.md
+++ b/collections/_articles/dear-bitcoiners-anoptimisticlettertofriendsandfoesaroundtheglobe.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2020/03/31/dear-bitcoiners/
 category: Through the Looking Glass
 date: Mar 31, 2020
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/dear-family-dear-friends-alettertoallofyouwhostillhavenobitcoin.md
+++ b/collections/_articles/dear-family-dear-friends-alettertoallofyouwhostillhavenobitcoin.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2020/04/27/dear-family-dear-friends/
 category: Through the Looking Glass
 date: Apr 27, 2020
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/dear-legacy-people.md
+++ b/collections/_articles/dear-legacy-people.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2020/03/20/dear-legacy-people/
 category: Through the Looking Glass
 date: Mar 20, 2020
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/digital-cash-privacy.md
+++ b/collections/_articles/digital-cash-privacy.md
@@ -6,4 +6,5 @@ link: https://nakamotoinstitute.org/digital-cash-and-privacy/
 category: Privacy
 date: Aug 19, 1993
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/enders-game.md
+++ b/collections/_articles/enders-game.md
@@ -6,4 +6,5 @@ link: https://unchained-capital.com/blog/enders-game/
 category: Misc
 date: Jul 26, 2019
 lesson: 12
+audio: 
 ---

--- a/collections/_articles/everyonesa-scammer.md
+++ b/collections/_articles/everyonesa-scammer.md
@@ -6,4 +6,5 @@ link: https://nakamotoinstitute.org/mempool/everyones-a-scammer/
 category: Misc
 date: Sep 11, 2014
 lesson: 
+audio: 
 ---

--- a/collections/_articles/fa-qfor-hodl-privacy.md
+++ b/collections/_articles/fa-qfor-hodl-privacy.md
@@ -6,4 +6,5 @@ link: https://github.com/6102bitcoin/FAQ/blob/master/hodl-privacy.md
 category: Privacy
 date: Jun 5, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/fa-qfor-samourai-wallets-whirlpool.md
+++ b/collections/_articles/fa-qfor-samourai-wallets-whirlpool.md
@@ -6,4 +6,5 @@ link: https://github.com/6102bitcoin/FAQ/blob/master/whirlpool.md
 category: Privacy
 date: Jul 7, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/fa-qfor-wasabi-wallet.md
+++ b/collections/_articles/fa-qfor-wasabi-wallet.md
@@ -6,4 +6,5 @@ link: https://github.com/6102bitcoin/FAQ/blob/master/wasabi.md
 category: Privacy
 date: May 2, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/forewordto-the-bitcoin-standard.md
+++ b/collections/_articles/forewordto-the-bitcoin-standard.md
@@ -6,4 +6,5 @@ link: https://medium.com/opacity/bitcoin-1537e616a074
 category: Bitcoin as a Living Organism
 date: Jan 22, 2018
 lesson: 
+audio: 
 ---

--- a/collections/_articles/gradually-then-suddenly.md
+++ b/collections/_articles/gradually-then-suddenly.md
@@ -6,4 +6,5 @@ link: https://www.unchained-capital.com/blog/dollar-crisis-to-bitcoin/
 category: Money
 date: Jul 26, 2019
 lesson: 11
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_290---Gradually--Then-Suddenly-Parker-Lewis-e55nu4/a-am1ik6
 ---

--- a/collections/_articles/guess-my-bitcoin-private-key.md
+++ b/collections/_articles/guess-my-bitcoin-private-key.md
@@ -6,4 +6,5 @@ link: https://medium.com/@kerbleski/a-dance-with-infinity-980bd8e9a781
 category: Misc
 date: Sep 28, 2017
 lesson: 
+audio: 
 ---

--- a/collections/_articles/how-lightning-layers-privacyon-topof-bitcoin.md
+++ b/collections/_articles/how-lightning-layers-privacyon-topof-bitcoin.md
@@ -6,4 +6,5 @@ link: https://bitcoinmagazine.com/articles/how-the-lightning-network-layers-priv
 category: Privacy
 date: Dec 19, 2016
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/how-privateis-bitcoin.md
+++ b/collections/_articles/how-privateis-bitcoin.md
@@ -6,4 +6,5 @@ link: https://medium.com/human-rights-foundation-hrf/privacy-and-cryptocurrency-
 category: Privacy
 date: Mar 7, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/howtheinternethaswovenitselfinto-americanlife.md
+++ b/collections/_articles/howtheinternethaswovenitselfinto-americanlife.md
@@ -6,4 +6,5 @@ link: https://www.pewinternet.org/2014/02/27/part-1-how-the-internet-has-woven-i
 category: Lesson Links
 date: Feb 27, 2014
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/howto-kill-bitcoin.md
+++ b/collections/_articles/howto-kill-bitcoin.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2019/10/03/how-to-kill-bitcoin/
 category: Through the Looking Glass
 date: Oct 3, 2019
 lesson: 6
+audio: 
 ---

--- a/collections/_articles/insidethe-worldofthe-bitcoin-carnivores-whyasmallcommunityof-bitcoinusersiseatingmeatexclusively.md
+++ b/collections/_articles/insidethe-worldofthe-bitcoin-carnivores-whyasmallcommunityof-bitcoinusersiseatingmeatexclusively.md
@@ -6,4 +6,5 @@ link: https://motherboard.vice.com/en_us/article/ne74nw/inside-the-world-of-the-
 category: Lesson Links
 date: Sep 29, 2017
 lesson: 1
+audio: 
 ---

--- a/collections/_articles/itsthesettlementassurancesstupid.md
+++ b/collections/_articles/itsthesettlementassurancesstupid.md
@@ -6,4 +6,5 @@ link: https://medium.com/@nic__carter/its-the-settlement-assurances-stupid-5dcd1
 category: Bitcoin's Uniqueness
 date: Jul 22, 2019
 lesson: 1
+audio: 
 ---

--- a/collections/_articles/mastersand-slavesof-money.md
+++ b/collections/_articles/mastersand-slavesof-money.md
@@ -6,4 +6,5 @@ link: https://medium.com/@breedlove22/masters-and-slaves-of-money-255ecc93404f
 category: Money
 date: Jul 5, 2020
 lesson: 11
+audio: https://anchor.fm/thecryptoconomy/episodes/Read_414---Masters--Slaves-of-Money---Part-1-Robert-Breedlove-egd95h/a-a2l01fg
 ---

--- a/collections/_articles/modeling-bitcoins-valuewith-scarcity.md
+++ b/collections/_articles/modeling-bitcoins-valuewith-scarcity.md
@@ -6,4 +6,5 @@ link: https://medium.com/@100trillionUSD/modeling-bitcoins-value-with-scarcity-9
 category: Lesson Links
 date: Mar 22, 2019
 lesson: 2
+audio: 
 ---

--- a/collections/_articles/moneyblockchainsandsocialscalability.md
+++ b/collections/_articles/moneyblockchainsandsocialscalability.md
@@ -6,4 +6,5 @@ link: http://unenumerated.blogspot.com/2017/02/money-blockchains-and-social-scal
 category: Money
 date: Feb 9, 2017
 lesson: 11
+audio: 
 ---

--- a/collections/_articles/nobody-understands-bitcoin-and-thats-ok.md
+++ b/collections/_articles/nobody-understands-bitcoin-and-thats-ok.md
@@ -6,4 +6,5 @@ link: https://www.coindesk.com/nobody-understands-bitcoin-thats-ok
 category: The Difficulty of Understanding Bitcoin
 date: Mar 11, 2017
 lesson: 
+audio: 
 ---

--- a/collections/_articles/nothingis-cheaperthan-proofof-work.md
+++ b/collections/_articles/nothingis-cheaperthan-proofof-work.md
@@ -6,4 +6,5 @@ link: http://www.truthcoin.info/blog/pow-cheapest/
 category: Proof-of-work
 date: Aug 4, 2015
 lesson: 17
+audio: 
 ---

--- a/collections/_articles/proofof-life-why-bitcoinisa-living-organism.md
+++ b/collections/_articles/proofof-life-why-bitcoinisa-living-organism.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2019/08/07/proof-of-life/
 category: Through the Looking Glass
 date: Aug 7, 2019
 lesson: 1
+audio: 
 ---

--- a/collections/_articles/protect-your-privacy.md
+++ b/collections/_articles/protect-your-privacy.md
@@ -6,4 +6,5 @@ link: https://bitcoin.org/en/protect-your-privacy
 category: Privacy
 date: Oct 2, 2013
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/reflectionson-trusting-trust.md
+++ b/collections/_articles/reflectionson-trusting-trust.md
@@ -6,4 +6,5 @@ link: https://www.archive.ece.cmu.edu/~ganger/712.fall02/papers/p761-thompson.pd
 category: Lesson Links
 date: Aug 1, 1984
 lesson: 16
+audio: 
 ---

--- a/collections/_articles/shelling-out-the-originsof-money.md
+++ b/collections/_articles/shelling-out-the-originsof-money.md
@@ -6,4 +6,5 @@ link: https://nakamotoinstitute.org/shelling-out/
 category: Money
 date: Dec 17, 2002
 lesson: 11
+audio: https://anchor.fm/thecryptoconomy/episodes/Reboot---Shelling-Out-The-Origins-of-Money-Nick-Szabo-e9omme/a-a17ga9a
 ---

--- a/collections/_articles/stagen-bitcoinexists.md
+++ b/collections/_articles/stagen-bitcoinexists.md
@@ -6,4 +6,5 @@ link: http://trilema.com/2013/stage-n-bitcoin-exists/
 category: Misc
 date: Feb 4, 2013
 lesson: 
+audio: 
 ---

--- a/collections/_articles/thatsnot-bitcointhats-b-cash.md
+++ b/collections/_articles/thatsnot-bitcointhats-b-cash.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/thats-not-bitcoin-that-s-bcash-f730f0d0a837
 category: Bitcoin's Identity
 date: Sep 23, 2017
 lesson: 
+audio: 
 ---

--- a/collections/_articles/thatsnot-bitcointhisis-bitcoin.md
+++ b/collections/_articles/thatsnot-bitcointhisis-bitcoin.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/thats-not-bitcoin-this-is-bitcoin-95f05a6fd6c2
 category: Bitcoin's Identity
 date: Sep 23, 2017
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-anatomyof-proofof-work.md
+++ b/collections/_articles/the-anatomyof-proofof-work.md
@@ -6,4 +6,5 @@ link: https://bitcointechtalk.com/the-anatomy-of-proof-of-work-98c85b6f6667
 category: Proof-of-work
 date: Feb 11, 2018
 lesson: 17
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_158---Anatomy-of-Proof-of-Work-Part-1---Hugo-Nguyen-e2ndpg/a-a7d5vg
 ---

--- a/collections/_articles/the-bitcoin-halvingand-monetary-competition.md
+++ b/collections/_articles/the-bitcoin-halvingand-monetary-competition.md
@@ -6,4 +6,5 @@ link: https://thesaifhouse.wordpress.com/2016/07/09/the-bitcoin-halving-and-mone
 category: Misc
 date: Jul 9, 2016
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-bitcoin-whitepaper.md
+++ b/collections/_articles/the-bitcoin-whitepaper.md
@@ -6,4 +6,5 @@ link: https://bitcoin.org/bitcoin.pdf
 category: Lesson Links
 date: Oct 31, 2008
 lesson: 16
+audio: 
 ---

--- a/collections/_articles/the-casefor-electronic-cash.md
+++ b/collections/_articles/the-casefor-electronic-cash.md
@@ -6,4 +6,5 @@ link: https://coincenter.org/files/2019-02/the-case-for-electronic-cash-coin-cen
 category: Privacy
 date: Feb 6, 2019
 lesson: 19
+audio: https://anchor.fm/thecryptoconomy/episodes/Chat_42---Project-Snow-White--the-Raleigh-Bitcoin-Meetup-egm6li/a-a2mih8u
 ---

--- a/collections/_articles/the-casefor-privacy.md
+++ b/collections/_articles/the-casefor-privacy.md
@@ -6,4 +6,5 @@ link: https://nakamotoinstitute.org/the-case-for-privacy/
 category: Privacy
 date: Jan 1, 2005
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/the-crypto-anarchist-manifesto.md
+++ b/collections/_articles/the-crypto-anarchist-manifesto.md
@@ -6,4 +6,5 @@ link: http://groups.csail.mit.edu/mac/classes/6.805/articles/crypto/cypherpunks/
 category: Cypherpunks
 date: Jan 1, 1988
 lesson: 20
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_300-----The-Crypto-Anarchist-Manifesto-Timothy-C--May-e5p7j4/a-apghds
 ---

--- a/collections/_articles/the-cyphernomicon.md
+++ b/collections/_articles/the-cyphernomicon.md
@@ -6,4 +6,5 @@ link: https://ia600208.us.archive.org/10/items/cyphernomicon/cyphernomicon.txt
 category: Cypherpunks
 date: Sep 10, 1994
 lesson: 20
+audio: 
 ---

--- a/collections/_articles/the-electricity-metaphorforthe-webs-future.md
+++ b/collections/_articles/the-electricity-metaphorforthe-webs-future.md
@@ -6,4 +6,5 @@ link: https://www.ted.com/talks/jeff_bezos_on_the_next_web_innovation
 category: Lesson Links
 date: Feb 1, 2003
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/the-god-protocols.md
+++ b/collections/_articles/the-god-protocols.md
@@ -6,4 +6,5 @@ link: https://nakamotoinstitute.org/the-god-protocols/
 category: Misc
 date: Jan 1, 1997
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-magic-dustof-cryptography-howdigitalinformationischangingoursociety.md
+++ b/collections/_articles/the-magic-dustof-cryptography-howdigitalinformationischangingoursociety.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2018/08/17/the-magic-dust-of-cryptography/
 category: Through the Looking Glass
 date: Aug 17, 2018
 lesson: 3
+audio: 
 ---

--- a/collections/_articles/the-many-facesof-bitcoin.md
+++ b/collections/_articles/the-many-facesof-bitcoin.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/the-many-faces-of-bitcoin-1c298570d191
 category: Bitcoin's Identity
 date: Apr 9, 2018
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-number-zeroand-bitcoin.md
+++ b/collections/_articles/the-number-zeroand-bitcoin.md
@@ -6,4 +6,5 @@ link: https://medium.com/@breedlove22/the-number-zero-and-bitcoin-4c193336db5b
 category: Bitcoin's Uniqueness
 date: Mar 29, 2020
 lesson: 
+audio: https://anchor.fm/thecryptoconomy/episodes/Read_374---The-Number-Zero--Bitcoin-Robert-Breedlove-ecbnnq
 ---

--- a/collections/_articles/the-oathof-machines-liturgyof-codeand-promiseof-bitcoin.md
+++ b/collections/_articles/the-oathof-machines-liturgyof-codeand-promiseof-bitcoin.md
@@ -6,4 +6,5 @@ link: https://cryptosovereignty.org/oath-machines-liturgy-code/
 category: A Social Revolution
 date: Jan 5, 2020
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-political-theologyof-bitcoin.md
+++ b/collections/_articles/the-political-theologyof-bitcoin.md
@@ -6,4 +6,5 @@ link: https://cryptosovereignty.org/the-political-theology-of-bitcoin/
 category: A Social Revolution
 date: Mar 29, 2020
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-riseofthe-sovereign-individual-howpowerisrealigningitselfinaninternetnativeworld.md
+++ b/collections/_articles/the-riseofthe-sovereign-individual-howpowerisrealigningitselfinaninternetnativeworld.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2019/08/22/the-rise-of-the-sovereign-individual/
 category: Through the Looking Glass
 date: Aug 22, 2019
 lesson: 6
+audio: 
 ---

--- a/collections/_articles/the-rising-speedof-technological-adoption.md
+++ b/collections/_articles/the-rising-speedof-technological-adoption.md
@@ -6,4 +6,5 @@ link: https://www.visualcapitalist.com/rising-speed-technological-adoption/
 category: Lesson Links
 date: Feb 14, 2018
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/the-theological-conquestof-money.md
+++ b/collections/_articles/the-theological-conquestof-money.md
@@ -6,4 +6,5 @@ link: https://cryptosovereignty.org/the-theological-conquest-of-money/
 category: A Social Revolution
 date: Aug 26, 2019
 lesson: 
+audio: 
 ---

--- a/collections/_articles/the-worldis-waking-upto-bitcoin.md
+++ b/collections/_articles/the-worldis-waking-upto-bitcoin.md
@@ -6,4 +6,5 @@ link: https://dergigi.com/2019/07/23/the-world-is-waking-up-to-bitcoin/
 category: Through the Looking Glass
 date: Jul 23, 2019
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/the7-network-effectsof-bitcoin.md
+++ b/collections/_articles/the7-network-effectsof-bitcoin.md
@@ -6,4 +6,5 @@ link: https://www.thrivenotes.com/the-7-network-effects-of-bitcoin/
 category: Lesson Links
 date: Jan 25, 2016
 lesson: 21
+audio: 
 ---

--- a/collections/_articles/thereisno-bitcoin20.md
+++ b/collections/_articles/thereisno-bitcoin20.md
@@ -6,4 +6,5 @@ link: http://www.contravex.com/2014/03/19/there-is-no-bitcoin-2-0
 category: Bitcoin's Uniqueness
 date: Mar 19, 2014
 lesson: 1
+audio: 
 ---

--- a/collections/_articles/trusted-third-parties-are-security-holes.md
+++ b/collections/_articles/trusted-third-parties-are-security-holes.md
@@ -6,4 +6,5 @@ link: https://nakamotoinstitute.org/trusted-third-parties/
 category: Misc
 date: Jan 1, 2001
 lesson: 16
+audio: 
 ---

--- a/collections/_articles/unpacking-bitcoins-social-contract.md
+++ b/collections/_articles/unpacking-bitcoins-social-contract.md
@@ -6,4 +6,5 @@ link: https://medium.com/s/story/bitcoins-social-contract-1f8b05ee24a9
 category: Who Controls Bitcoin?
 date: Dec 4, 2018
 lesson: 1
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_198---Unpacking-Bitcoins-Social-Contract-Hasu-e2oct5/a-a7k54h
 ---

--- a/collections/_articles/we-must-protectour-abilityto-transact-privately-online.md
+++ b/collections/_articles/we-must-protectour-abilityto-transact-privately-online.md
@@ -6,4 +6,5 @@ link: https://coincenter.org/entry/we-must-protect-our-ability-to-transact-priva
 category: Privacy
 date: Feb 6, 2019
 lesson: 19
+audio: 
 ---

--- a/collections/_articles/what-is-it-liketobea-bat.md
+++ b/collections/_articles/what-is-it-liketobea-bat.md
@@ -6,4 +6,5 @@ link: https://en.wikipedia.org/wiki/What_Is_it_Like_to_Be_a_Bat%3F
 category: Lesson Links
 date: Oct 1, 1974
 lesson: 4
+audio: 
 ---

--- a/collections/_articles/whatisitliketobea-bitcoin.md
+++ b/collections/_articles/whatisitliketobea-bitcoin.md
@@ -6,4 +6,5 @@ link: https://medium.com/s/story/what-is-it-like-to-be-a-bitcoin-56109f3e6753
 category: Bitcoin's Identity
 date: Nov 1, 2018
 lesson: 4
+audio: 
 ---

--- a/collections/_articles/where-am-i.md
+++ b/collections/_articles/where-am-i.md
@@ -6,4 +6,5 @@ link: https://www.lehigh.edu/~mhb0/Dennett-WhereAmI.pdf
 category: Lesson Links
 date: Jan 1, 1981
 lesson: 3
+audio: 
 ---

--- a/collections/_articles/why-america-cant-regulate-bitcoin.md
+++ b/collections/_articles/why-america-cant-regulate-bitcoin.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/why-america-cant-regulate-bitcoin-8c77cee8d794
 category: Who Controls Bitcoin?
 date: Mar 15, 2018
 lesson: 6
+audio: https://anchor.fm/thecryptoconomy/episodes/CryptoQuikRead_260---Why-America-Cant-Regulate-Bitcoin-beautyon_-e4b4s8/a-ah3bvg
 ---

--- a/collections/_articles/why-bitcoin-matters.md
+++ b/collections/_articles/why-bitcoin-matters.md
@@ -6,4 +6,5 @@ link: https://hackernoon.com/why-bitcoin-matters-c8bf733b9fad
 category: Bitcoin's Uniqueness
 date: Feb 18, 2019
 lesson: 
+audio: 
 ---

--- a/collections/_articles/why-bitcoin-mattersfor-freedom.md
+++ b/collections/_articles/why-bitcoin-mattersfor-freedom.md
@@ -6,4 +6,5 @@ link: https://time.com/5486673/bitcoin-venezuela-authoritarian/?amp=true
 category: Privacy
 date: Feb 28, 2019
 lesson: 6
+audio: 
 ---

--- a/collections/_articles/why-bitcoinis-different.md
+++ b/collections/_articles/why-bitcoinis-different.md
@@ -6,4 +6,5 @@ link: https://medium.com/@jimmysong/why-bitcoin-is-different-e17b813fd947
 category: Bitcoin's Uniqueness
 date: Apr 2, 2018
 lesson: 5
+audio: 
 ---

--- a/collections/_articles/why-blockchainis-hard.md
+++ b/collections/_articles/why-blockchainis-hard.md
@@ -6,4 +6,5 @@ link: https://medium.com/@jimmysong/why-blockchain-is-hard-60416ea4c5c
 category: The Difficulty of Understanding Bitcoin
 date: May 14, 2018
 lesson: 
+audio: 
 ---

--- a/collections/_articles/why-its-hardto-get-bitcoin.md
+++ b/collections/_articles/why-its-hardto-get-bitcoin.md
@@ -6,4 +6,5 @@ link: https://blog.unchained-capital.com/blockchain-spectrum-806847e1c575
 category: The Difficulty of Understanding Bitcoin
 date: Dec 1, 2017
 lesson: 
+audio: 
 ---

--- a/collections/_articles/workis-timeless-stakeis-not.md
+++ b/collections/_articles/workis-timeless-stakeis-not.md
@@ -6,4 +6,5 @@ link: https://medium.com/@hugonguyen/work-is-timeless-stake-is-not-554c4450ce18
 category: Proof-of-work
 date: Oct 12, 2018
 lesson: 17
+audio: 
 ---

--- a/scripts/spreadsheet_to_resource_mds/update_articles.py
+++ b/scripts/spreadsheet_to_resource_mds/update_articles.py
@@ -25,8 +25,9 @@ for row in articles.get_all_values():
     article_title = row[1].lstrip().rstrip()
     article_link = row[2].lstrip().rstrip()
     article_category = row[3]
-    article_date = row[4] if row[4] != '' else NO_DATE
-    article_lesson = row[5].lstrip().rstrip()
+    article_audio = row[4].lstrip().rstrip()
+    article_date = row[5] if row[5] != '' else NO_DATE
+    article_lesson = row[6].lstrip().rstrip()
 
     md_file_path = title_to_file_path(article_title, 'articles')
     if md_file_path == "":
@@ -39,6 +40,7 @@ for row in articles.get_all_values():
                 f"title: {article_title}\n"
                 f"link: {article_link}\n"
                 f"category: {article_category}\n"
+                f"audio: {article_audio}\n"
                 f"date: {article_date}\n"
                 f"lesson: {article_lesson}\n"
                 f"---\n")

--- a/scripts/spreadsheet_to_resource_mds/update_articles.py
+++ b/scripts/spreadsheet_to_resource_mds/update_articles.py
@@ -25,9 +25,9 @@ for row in articles.get_all_values():
     article_title = row[1].lstrip().rstrip()
     article_link = row[2].lstrip().rstrip()
     article_category = row[3]
-    article_audio = row[4].lstrip().rstrip()
-    article_date = row[5] if row[5] != '' else NO_DATE
-    article_lesson = row[6].lstrip().rstrip()
+    article_date = row[4] if row[4] != '' else NO_DATE
+    article_lesson = row[5].lstrip().rstrip()
+    article_audio = row[6].lstrip().rstrip()
 
     md_file_path = title_to_file_path(article_title, 'articles')
     if md_file_path == "":
@@ -40,9 +40,9 @@ for row in articles.get_all_values():
                 f"title: {article_title}\n"
                 f"link: {article_link}\n"
                 f"category: {article_category}\n"
-                f"audio: {article_audio}\n"
                 f"date: {article_date}\n"
                 f"lesson: {article_lesson}\n"
+                f"audio: {article_audio}\n"
                 f"---\n")
 
     with open(md_file_path, 'w') as f:


### PR DESCRIPTION

* Updated article scraper
* Add :headphones: symbol to articles that have audio versions
* Clicking on the :headphones: symbol will link to the audio version (usually [Bitcoin Audible](https://bitcoinaudible.com/) episode on [Anchor](https://anchor.fm/thecryptoconomy))

![Screenshot from 2020-07-14 10-26-21](https://user-images.githubusercontent.com/109058/87403554-4e37ec00-c5bd-11ea-91bf-f2850ff85bd0.png)
