### PR TITLE
feat(pods): add podcasts page and add tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ title: Resources
 
 ### Bitcoin Resources Changelog
 
+#### 2020-09-27
+
+- Add features:
+  - New /podcasts page
+  - Tag support for podcasts
+  - New categories for podcasts: beginner, intermediate, advanced, specialized
+
+- Add podcasts:
+  - HASHR8 podcast
+  - Lightning Junkies podcast
+  - The Van Wirdum Sjorsnado
+
 #### 2020-08-31
 - Add podcast:
   - The Bitcoin Standard Podcast by Saifedean

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,4 +1,4 @@
-{% if page.path contains '_books' %}
+{% if page.path contains '_books' or page.path contains 'podcasts'  %}
 {% assign prefix = "../" %}
 {% endif %}
 <nav>

--- a/_includes/podcasts.html
+++ b/_includes/podcasts.html
@@ -6,6 +6,12 @@
     <a href="{{ pod.rss }}" target="_blank"><i class="fa fa-rss"></i></a>
     <a href="{{ pod.link }}" target="_blank">{{ pod.name }}</a>
     [
+    {% if pod.tags %}
+      {% for tag in pod.tags %}
+      {% include tag.html tag=tag %}
+      {% endfor %}
+      |
+    {% endif %}
     <a href="{{ pod.android }}" target="_blank"><i class="fa fa-android"></i></a>
     <a href="{{ pod.ios }}" target="_blank"><i class="fa fa-apple"></i></a>
     {% if pod.youtube or pod.spotify %}

--- a/_includes/podcasts.html
+++ b/_includes/podcasts.html
@@ -1,4 +1,12 @@
-{% assign sorted_pods = site.podcasts | where: 'tier', include.tier | sort: 'rank' %}
+{% assign sorted_pods = site.podcasts %}
+
+{% if include.tier %}
+  {% assign sorted_pods = site.podcasts | where: 'tier', include.tier | sort: 'rank' %}
+{% endif %}
+
+{% if include.level %}
+  {% assign sorted_pods = site.podcasts | where: 'level', include.level | sort: 'rank' %}
+{% endif %}
 
 <ul class="podcasts">
 {% for pod in sorted_pods %}

--- a/_includes/tag.html
+++ b/_includes/tag.html
@@ -18,6 +18,10 @@
 {% assign emoji = '👔' %}
 {% when 'shitcoinery' %}
 {% assign emoji = '💩' %}
+{% when 'lightning' %}
+{% assign emoji = '⚡' %}
+{% when 'mining' %}
+{% assign emoji = '⚒️' %}
 {% when 'inactive' %}
 {% assign emoji = '⚰️' %}
 {% else %}

--- a/_includes/tag.html
+++ b/_includes/tag.html
@@ -18,6 +18,8 @@
 {% assign emoji = '👔' %}
 {% when 'shitcoinery' %}
 {% assign emoji = '💩' %}
+{% when 'inactive' %}
+{% assign emoji = '⚰️' %}
 {% else %}
 {% endcase %}
 

--- a/_includes/tag.html
+++ b/_includes/tag.html
@@ -1,0 +1,24 @@
+{% assign emoji = '' %}
+{% case tag %}
+{% when 'entertainment' %}
+{% assign emoji = '😆' %}
+{% when 'news' %}
+{% assign emoji = '📰' %}
+{% when 'interviews' %}
+{% assign emoji = '💬' %}
+{% when 'economics' %}
+{% assign emoji = '💹' %}
+{% when 'technical' %}
+{% assign emoji = '⚙️' %}
+{% when 'roundtable' %}
+{% assign emoji = '👥' %}
+{% when 'pleb' %}
+{% assign emoji = '🌮' %}
+{% when 'industry' %}
+{% assign emoji = '👔' %}
+{% when 'shitcoinery' %}
+{% assign emoji = '💩' %}
+{% else %}
+{% endcase %}
+
+<a href="/podcasts/{{ tag }}" title="{{ tag }}">{{ emoji }}</a>

--- a/_includes/tag.html
+++ b/_includes/tag.html
@@ -23,4 +23,4 @@
 {% else %}
 {% endcase %}
 
-<a href="/podcasts/{{ tag }}" title="{{ tag }}">{{ emoji }}</a>
+<span title="{{ tag }}">{{ emoji }}</span>

--- a/collections/_podcasts/BA.md
+++ b/collections/_podcasts/BA.md
@@ -13,5 +13,5 @@ rank: 4
 twitter: https://twitter.com/BitcoinAudible
 youtube: https://www.youtube.com/channel/UClG-wqz-OuXfzbpqwJd3fVA
 level: Beginner
-tags: ['economics', ' technical']
+tags: ['economics', 'technical']
 ---

--- a/collections/_podcasts/BA.md
+++ b/collections/_podcasts/BA.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/80d5cfc/podcast/rss']
 rank: 5
 twitter: https://twitter.com/BitcoinAudible
 youtube: https://www.youtube.com/channel/UClG-wqz-OuXfzbpqwJd3fVA
+level: Beginner
+tags: ['community', ' macro']
 ---

--- a/collections/_podcasts/BA.md
+++ b/collections/_podcasts/BA.md
@@ -12,6 +12,6 @@ rss: ['https://anchor.fm/s/80d5cfc/podcast/rss']
 rank: 4
 twitter: https://twitter.com/BitcoinAudible
 youtube: https://www.youtube.com/channel/UClG-wqz-OuXfzbpqwJd3fVA
-level: Beginner
+level: Intermediate
 tags: ['economics', 'technical']
 ---

--- a/collections/_podcasts/BA.md
+++ b/collections/_podcasts/BA.md
@@ -4,14 +4,14 @@ code: BA
 name: Bitcoin Audible
 hosts: Guy Swann
 link: http://bitcoinaudible.com/
-tier: 2
+tier: 1
 ios: https://podcasts.apple.com/us/podcast/bitcoin-audible-previously-the-cryptoconomy/id1359544516
 android: ['https://subscribeonandroid.com/anchor.fm/s/80d5cfc/podcast/rss']
 spotify: https://open.spotify.com/show/16c6WR2znCZM1wveeeJoSz?si=Y3CtwrzSQYGekbBUtllPmQ
 rss: ['https://anchor.fm/s/80d5cfc/podcast/rss']
-rank: 5
+rank: 4
 twitter: https://twitter.com/BitcoinAudible
 youtube: https://www.youtube.com/channel/UClG-wqz-OuXfzbpqwJd3fVA
 level: Beginner
-tags: ['community', ' macro']
+tags: ['economics', ' technical']
 ---

--- a/collections/_podcasts/BAND.md
+++ b/collections/_podcasts/BAND.md
@@ -12,6 +12,6 @@ rss: ['http://feeds.soundcloud.com/users/soundcloud:users:108074218/sounds.rss']
 rank: 12
 twitter: https://twitter.com/bennd77
 youtube: 
-level: 
-tags: ['']
+level: Intermediate
+tags: ['news', ' entertainment', ' pleb']
 ---

--- a/collections/_podcasts/BAND.md
+++ b/collections/_podcasts/BAND.md
@@ -13,5 +13,5 @@ rank: 12
 twitter: https://twitter.com/bennd77
 youtube: 
 level: Intermediate
-tags: ['news', ' entertainment', ' pleb']
+tags: ['news', 'entertainment', 'pleb']
 ---

--- a/collections/_podcasts/BAND.md
+++ b/collections/_podcasts/BAND.md
@@ -12,4 +12,6 @@ rss: ['http://feeds.soundcloud.com/users/soundcloud:users:108074218/sounds.rss']
 rank: 12
 twitter: https://twitter.com/bennd77
 youtube: 
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/BCO.md
+++ b/collections/_podcasts/BCO.md
@@ -13,5 +13,5 @@ rank: 20
 twitter: https://twitter.com/anitaposch
 youtube: https://www.youtube.com/c/AnitaPosch
 level: Intermediate
-tags: ['interviews', ' economics']
+tags: ['interviews', 'economics']
 ---

--- a/collections/_podcasts/BCO.md
+++ b/collections/_podcasts/BCO.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/at/podcast/bitcoin-co-with-anita-posch-english/i
 android: ['https://subscribeonandroid.com/bitcoinundco.com/en/feed/mp3/']
 spotify: https://open.spotify.com/show/0EJu3cMWF0AMxeO8NMH71z
 rss: ['https://bitcoinundco.com/en/feed/mp3/']
-rank: 22
+rank: 20
 twitter: https://twitter.com/anitaposch
 youtube: https://www.youtube.com/c/AnitaPosch
 level: Intermediate
-tags: ['non-technical', ' macro']
+tags: ['interviews', ' economics']
 ---

--- a/collections/_podcasts/BCO.md
+++ b/collections/_podcasts/BCO.md
@@ -12,4 +12,6 @@ rss: ['https://bitcoinundco.com/en/feed/mp3/']
 rank: 22
 twitter: https://twitter.com/anitaposch
 youtube: https://www.youtube.com/c/AnitaPosch
+level: Intermediate
+tags: ['non-technical', ' macro']
 ---

--- a/collections/_podcasts/BEC.md
+++ b/collections/_podcasts/BEC.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/8f267c0/podcast/rss']
 rank: 11
 twitter: https://twitter.com/heavilyarmedc
 youtube: 
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/BEC.md
+++ b/collections/_podcasts/BEC.md
@@ -13,5 +13,5 @@ rank: 11
 twitter: https://twitter.com/heavilyarmedc
 youtube: 
 level: Intermediate
-tags: ['interviews', ' pleb']
+tags: ['interviews', 'pleb']
 ---

--- a/collections/_podcasts/BEC.md
+++ b/collections/_podcasts/BEC.md
@@ -12,6 +12,6 @@ rss: ['https://anchor.fm/s/8f267c0/podcast/rss']
 rank: 11
 twitter: https://twitter.com/heavilyarmedc
 youtube: 
-level: 
-tags: ['']
+level: Intermediate
+tags: ['interviews', ' pleb']
 ---

--- a/collections/_podcasts/BFT.md
+++ b/collections/_podcasts/BFT.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/2a4e8034/podcast/rss']
 rank: 9
 twitter: https://twitter.com/jimmysong
 youtube: https://www.youtube.com/c/OffChainwithJimmySong
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/BFT.md
+++ b/collections/_podcasts/BFT.md
@@ -12,6 +12,6 @@ rss: ['https://anchor.fm/s/2a4e8034/podcast/rss']
 rank: 9
 twitter: https://twitter.com/jimmysong
 youtube: https://www.youtube.com/c/OffChainwithJimmySong
-level: 
-tags: ['']
+level: Advanced
+tags: ['interviews']
 ---

--- a/collections/_podcasts/BKP.md
+++ b/collections/_podcasts/BKP.md
@@ -4,12 +4,12 @@ code: BKP
 name: The Bitcoin Knowledge Podcast
 hosts: Trace Mayer
 link: https://www.bitcoin.kn/about/
-tier: 4
+tier: 0
 ios: https://podcasts.apple.com/us/podcast/the-bitcoin-knowledge-podcast/id301670981
 android: ['https://subscribeonandroid.com/www.bitcoin.kn/feed/podcast/']
 spotify: 
 rss: ['https://www.bitcoin.kn/feed/podcast/']
-rank: 26
+rank: 
 twitter: https://twitter.com/bitcoinkn
 youtube: 
 level: 

--- a/collections/_podcasts/BKP.md
+++ b/collections/_podcasts/BKP.md
@@ -4,14 +4,14 @@ code: BKP
 name: The Bitcoin Knowledge Podcast
 hosts: Trace Mayer
 link: https://www.bitcoin.kn/about/
-tier: 3
+tier: 4
 ios: https://podcasts.apple.com/us/podcast/the-bitcoin-knowledge-podcast/id301670981
 android: ['https://subscribeonandroid.com/www.bitcoin.kn/feed/podcast/']
 spotify: 
 rss: ['https://www.bitcoin.kn/feed/podcast/']
-rank: 18
+rank: 26
 twitter: https://twitter.com/bitcoinkn
 youtube: 
 level: 
-tags: ['']
+tags: ['inactive']
 ---

--- a/collections/_podcasts/BKP.md
+++ b/collections/_podcasts/BKP.md
@@ -12,4 +12,6 @@ rss: ['https://www.bitcoin.kn/feed/podcast/']
 rank: 18
 twitter: https://twitter.com/bitcoinkn
 youtube: 
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/BRF.md
+++ b/collections/_podcasts/BRF.md
@@ -12,6 +12,6 @@ rss: ['https://anchor.fm/s/d6b3354/podcast/rss']
 rank: 3
 twitter: https://twitter.com/johnkvallis
 youtube: https://www.youtube.com/channel/UCyNBrVfqzd2zN2yhwk-YT2A
-level: 
-tags: ['']
+level: Beginner
+tags: ['interviews']
 ---

--- a/collections/_podcasts/BRF.md
+++ b/collections/_podcasts/BRF.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/d6b3354/podcast/rss']
 rank: 3
 twitter: https://twitter.com/johnkvallis
 youtube: https://www.youtube.com/channel/UCyNBrVfqzd2zN2yhwk-YT2A
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/BSB.md
+++ b/collections/_podcasts/BSB.md
@@ -13,5 +13,5 @@ rank: 23
 twitter: https://twitter.com/BottomshelfBTC
 youtube: https://www.youtube.com/channel/UC-vAqJTaPrkCqD0zfpT_6PQ
 level: Intermediate
-tags: ['community', ' interviews']
+tags: ['community', 'interviews']
 ---

--- a/collections/_podcasts/BSB.md
+++ b/collections/_podcasts/BSB.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/us/podcast/bottomshelf-bitcoin/id1335227408
 android: ['https://subscribeonandroid.com/anchor.fm/s/85e0e68/podcast/rss']
 spotify: https://open.spotify.com/show/2PxHTIGRKR05TiWoRwsC3S
 rss: ['https://anchor.fm/s/85e0e68/podcast/rss']
-rank: 26
+rank: 23
 twitter: https://twitter.com/BottomshelfBTC
 youtube: https://www.youtube.com/channel/UC-vAqJTaPrkCqD0zfpT_6PQ
-level: 
-tags: ['']
+level: Intermediate
+tags: ['community', ' interviews']
 ---

--- a/collections/_podcasts/BSB.md
+++ b/collections/_podcasts/BSB.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/85e0e68/podcast/rss']
 rank: 26
 twitter: https://twitter.com/BottomshelfBTC
 youtube: https://www.youtube.com/channel/UC-vAqJTaPrkCqD0zfpT_6PQ
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/CAG.md
+++ b/collections/_podcasts/CAG.md
@@ -12,4 +12,6 @@ rss: ['https://cryptoandgrill.podbean.com/feed.xml']
 rank: 20
 twitter: https://twitter.com/cryptoandgrill
 youtube: https://www.youtube.com/channel/UCB1Mjmtdtq7r9o-uPLBQL6A
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/CAG.md
+++ b/collections/_podcasts/CAG.md
@@ -4,12 +4,12 @@ code: CAG
 name: Crypto & Grill
 hosts: CryptoDantes and StigofthePump
 link: https://twitter.com/cryptoandgrill
-tier: 4
+tier: 0
 ios: https://podcasts.apple.com/gb/podcast/crypto-grill/id1430003296
 android: ['https://subscribeonandroid.com/cryptoandgrill.podbean.com/feed.xml']
 spotify: https://open.spotify.com/show/7srddOExupnrf8mvWpVrkE?si=Rbh6mHq5Qru6b3JJlI8G6g
 rss: ['https://cryptoandgrill.podbean.com/feed.xml']
-rank: 27
+rank: 
 twitter: https://twitter.com/cryptoandgrill
 youtube: https://www.youtube.com/channel/UCB1Mjmtdtq7r9o-uPLBQL6A
 level: 

--- a/collections/_podcasts/CAG.md
+++ b/collections/_podcasts/CAG.md
@@ -4,14 +4,14 @@ code: CAG
 name: Crypto & Grill
 hosts: CryptoDantes and StigofthePump
 link: https://twitter.com/cryptoandgrill
-tier: 3
+tier: 4
 ios: https://podcasts.apple.com/gb/podcast/crypto-grill/id1430003296
 android: ['https://subscribeonandroid.com/cryptoandgrill.podbean.com/feed.xml']
 spotify: https://open.spotify.com/show/7srddOExupnrf8mvWpVrkE?si=Rbh6mHq5Qru6b3JJlI8G6g
 rss: ['https://cryptoandgrill.podbean.com/feed.xml']
-rank: 20
+rank: 27
 twitter: https://twitter.com/cryptoandgrill
 youtube: https://www.youtube.com/channel/UCB1Mjmtdtq7r9o-uPLBQL6A
 level: 
-tags: ['']
+tags: ['inactive']
 ---

--- a/collections/_podcasts/CB.md
+++ b/collections/_podcasts/CB.md
@@ -4,14 +4,14 @@ code: CB
 name: Citizen Bitcoin
 hosts: Brady Swenson
 link: https://citizenbitcoin.world/
-tier: 2
+tier: 1
 ios: https://podcasts.apple.com/us/podcast/citizen-bitcoin/id1350483937
 android: ['https://subscribeonandroid.com/feeds.simplecast.com/620_gQYv']
 spotify: https://open.spotify.com/show/2R9ypQf38jKV5QbYIIeZaV?si=0YQ7Dl3sTPmVFMgmwavLog
 rss: ['https://feeds.simplecast.com/620_gQYv']
-rank: 6
+rank: 5
 twitter: https://twitter.com/CitizenBitcoin
 youtube: https://www.youtube.com/channel/UCi_fqW5K7-eLUXcLU-dR3eQ
-level: 
-tags: ['']
+level: Beginner
+tags: ['interviews']
 ---

--- a/collections/_podcasts/CB.md
+++ b/collections/_podcasts/CB.md
@@ -12,4 +12,6 @@ rss: ['https://feeds.simplecast.com/620_gQYv']
 rank: 6
 twitter: https://twitter.com/CitizenBitcoin
 youtube: https://www.youtube.com/channel/UCi_fqW5K7-eLUXcLU-dR3eQ
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/CV.md
+++ b/collections/_podcasts/CV.md
@@ -12,4 +12,6 @@ rss: ['https://feeds.soundcloud.com/users/soundcloud:users:246365412/sounds.rss'
 rank: 15
 twitter: https://twitter.com/crypto_voices
 youtube: 
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/CV.md
+++ b/collections/_podcasts/CV.md
@@ -12,6 +12,6 @@ rss: ['https://feeds.soundcloud.com/users/soundcloud:users:246365412/sounds.rss'
 rank: 15
 twitter: https://twitter.com/crypto_voices
 youtube: 
-level: 
-tags: ['']
+level: Intermediate
+tags: ['interviews']
 ---

--- a/collections/_podcasts/DYKC.md
+++ b/collections/_podcasts/DYKC.md
@@ -12,4 +12,6 @@ rss: ['https://didyouknowcrypto.com/feed/']
 rank: 25
 twitter: https://twitter.com/DustinDry1st
 youtube: https://www.youtube.com/channel/UCGDMTdSf3vagLhLIQVCYDxQ
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/DYKC.md
+++ b/collections/_podcasts/DYKC.md
@@ -4,12 +4,12 @@ code: DYKC
 name: Did You Know Crypto
 hosts: Dustin D.
 link: https://didyouknowcrypto.com/
-tier: 4
+tier: 0
 ios: https://podcasts.apple.com/us/podcast/did-you-know-podcast/id1368275736
 android: ['https://subscribeonandroid.com/didyouknowcrypto.com/feed/podcast/']
 spotify: https://open.spotify.com/show/4yZMm1QD34DHRulrOElo00?si=Wl3JXwGUSa29dbGgDJKeGQ
 rss: ['https://didyouknowcrypto.com/feed/']
-rank: 29
+rank: 
 twitter: https://twitter.com/DustinDry1st
 youtube: https://www.youtube.com/channel/UCGDMTdSf3vagLhLIQVCYDxQ
 level: 

--- a/collections/_podcasts/DYKC.md
+++ b/collections/_podcasts/DYKC.md
@@ -4,14 +4,14 @@ code: DYKC
 name: Did You Know Crypto
 hosts: Dustin D.
 link: https://didyouknowcrypto.com/
-tier: 3
+tier: 4
 ios: https://podcasts.apple.com/us/podcast/did-you-know-podcast/id1368275736
 android: ['https://subscribeonandroid.com/didyouknowcrypto.com/feed/podcast/']
 spotify: https://open.spotify.com/show/4yZMm1QD34DHRulrOElo00?si=Wl3JXwGUSa29dbGgDJKeGQ
 rss: ['https://didyouknowcrypto.com/feed/']
-rank: 25
+rank: 29
 twitter: https://twitter.com/DustinDry1st
 youtube: https://www.youtube.com/channel/UCGDMTdSf3vagLhLIQVCYDxQ
 level: 
-tags: ['']
+tags: ['inactive']
 ---

--- a/collections/_podcasts/FWB.md
+++ b/collections/_podcasts/FWB.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/889e768/podcast/rss']
 rank: 14
 twitter: https://twitter.com/Coinicarus
 youtube: https://www.youtube.com/channel/UCa0ZTLukeshFoZYmYvQfLHw
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/FWB.md
+++ b/collections/_podcasts/FWB.md
@@ -13,5 +13,5 @@ rank: 14
 twitter: https://twitter.com/Coinicarus
 youtube: https://www.youtube.com/channel/UCa0ZTLukeshFoZYmYvQfLHw
 level: Beginner
-tags: ['community', ' interviews']
+tags: ['interviews', 'pleb']
 ---

--- a/collections/_podcasts/FWB.md
+++ b/collections/_podcasts/FWB.md
@@ -12,6 +12,6 @@ rss: ['https://anchor.fm/s/889e768/podcast/rss']
 rank: 14
 twitter: https://twitter.com/Coinicarus
 youtube: https://www.youtube.com/channel/UCa0ZTLukeshFoZYmYvQfLHw
-level: 
-tags: ['']
+level: Beginner
+tags: ['community', ' interviews']
 ---

--- a/collections/_podcasts/HR8.md
+++ b/collections/_podcasts/HR8.md
@@ -1,0 +1,17 @@
+---
+layout: page
+code: HR8
+name: HASHR8
+hosts: Whit Gibbs
+link: https://www.hashr8.com/
+tier: 
+ios: https://podcasts.apple.com/us/podcast/hashr8-podcast/id1450932045?uo=4
+android: ['https://subscribeonandroid.com/anchor.fm/s/1242392c/podcast/rss']
+spotify: https://open.spotify.com/show/2CLetGT20MFsHqfeBN3fYl
+rss: ['https://anchor.fm/s/1242392c/podcast/rss']
+rank: 27
+twitter: https://twitter.com/H4shr8
+youtube: https://www.youtube.com/channel/UCKSkY12vKI8ch2hFhOQrZgg
+level: Specific
+tags: ['mining']
+---

--- a/collections/_podcasts/HR8.md
+++ b/collections/_podcasts/HR8.md
@@ -4,7 +4,7 @@ code: HR8
 name: HASHR8
 hosts: Whit Gibbs
 link: https://www.hashr8.com/
-tier: 
+tier:
 ios: https://podcasts.apple.com/us/podcast/hashr8-podcast/id1450932045?uo=4
 android: ['https://subscribeonandroid.com/anchor.fm/s/1242392c/podcast/rss']
 spotify: https://open.spotify.com/show/2CLetGT20MFsHqfeBN3fYl
@@ -12,6 +12,6 @@ rss: ['https://anchor.fm/s/1242392c/podcast/rss']
 rank: 27
 twitter: https://twitter.com/H4shr8
 youtube: https://www.youtube.com/channel/UCKSkY12vKI8ch2hFhOQrZgg
-level: Specific
+level: Specialized
 tags: ['mining']
 ---

--- a/collections/_podcasts/LJ.md
+++ b/collections/_podcasts/LJ.md
@@ -1,0 +1,17 @@
+---
+layout: page
+code: LJ
+name: Lightning Junkies
+hosts: Chaz Bolty
+link: https://lightningjunkies.net/
+tier: 
+ios: https://podcasts.apple.com/us/podcast/lightning-junkies/id1477726305
+android: ['https://subscribeonandroid.com/anchor.fm/s/ce6ee00/podcast/rss']
+spotify: https://open.spotify.com/show/2xGRogYPU9Zq5AhivdAG5w
+rss: ['https://lightningjunkies.net/rss']
+rank: 26
+twitter: https://twitter.com/thechaz
+youtube: https://www.youtube.com/channel/UCWbkcoBsKAJWJ0kIYyblH0g
+level: Specific
+tags: ['lightning']
+---

--- a/collections/_podcasts/LJ.md
+++ b/collections/_podcasts/LJ.md
@@ -4,7 +4,7 @@ code: LJ
 name: Lightning Junkies
 hosts: Chaz Bolty
 link: https://lightningjunkies.net/
-tier: 
+tier:
 ios: https://podcasts.apple.com/us/podcast/lightning-junkies/id1477726305
 android: ['https://subscribeonandroid.com/anchor.fm/s/ce6ee00/podcast/rss']
 spotify: https://open.spotify.com/show/2xGRogYPU9Zq5AhivdAG5w
@@ -12,6 +12,6 @@ rss: ['https://lightningjunkies.net/rss']
 rank: 26
 twitter: https://twitter.com/thechaz
 youtube: https://www.youtube.com/channel/UCWbkcoBsKAJWJ0kIYyblH0g
-level: Specific
+level: Specialized
 tags: ['lightning']
 ---

--- a/collections/_podcasts/LTB.md
+++ b/collections/_podcasts/LTB.md
@@ -12,4 +12,6 @@ rss: ['https://letstalkbitcoin.com/rss/feed/blog?limit=9001&soundcloud-id=true&a
 rank: 17
 twitter: https://twitter.com/theltbnetwork
 youtube: https://www.youtube.com/user/LetsTalkBitcoinChan
+level: Intermediate
+tags: ['non-technical', ' technical']
 ---

--- a/collections/_podcasts/LTB.md
+++ b/collections/_podcasts/LTB.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/us/podcast/lets-talk-bitcoin/id1463398832
 android: ['https://subscribeonandroid.com/anchor.fm/s/b421fd4/podcast/rss']
 spotify: https://open.spotify.com/show/3fW8PuRQ4uvdOrI4ZM7yle?si=wQCnQEjJSvWJS3JvE3rAEQ
 rss: ['https://letstalkbitcoin.com/rss/feed/blog?limit=9001&soundcloud-id=true&audio-url=true&sites=1']
-rank: 17
+rank: 18
 twitter: https://twitter.com/theltbnetwork
 youtube: https://www.youtube.com/user/LetsTalkBitcoinChan
 level: Intermediate
-tags: ['non-technical', ' technical']
+tags: ['technical']
 ---

--- a/collections/_podcasts/NLW.md
+++ b/collections/_podcasts/NLW.md
@@ -13,5 +13,5 @@ rank: 13
 twitter: https://twitter.com/BreakdownNLW
 youtube: 
 level: Intermediate
-tags: ['news']
+tags: ['news', 'industry', 'shitcoinery']
 ---

--- a/collections/_podcasts/NLW.md
+++ b/collections/_podcasts/NLW.md
@@ -12,6 +12,6 @@ rss: ['http://nlwcrypto.libsyn.com/rss']
 rank: 13
 twitter: https://twitter.com/BreakdownNLW
 youtube: 
-level: 
-tags: ['']
+level: Intermediate
+tags: ['news']
 ---

--- a/collections/_podcasts/NLW.md
+++ b/collections/_podcasts/NLW.md
@@ -12,4 +12,6 @@ rss: ['http://nlwcrypto.libsyn.com/rss']
 rank: 13
 twitter: https://twitter.com/BreakdownNLW
 youtube: 
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/NODED.md
+++ b/collections/_podcasts/NODED.md
@@ -12,4 +12,6 @@ rss: ['https://noded.org/feed.xml']
 rank: 4
 twitter: https://twitter.com/NodedPodcast
 youtube: https://www.youtube.com/channel/UC3j-JWXorlfMwkDfsJjdWmQ
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/NODED.md
+++ b/collections/_podcasts/NODED.md
@@ -13,5 +13,5 @@ rank: 6
 twitter: https://twitter.com/NodedPodcast
 youtube: https://www.youtube.com/channel/UC3j-JWXorlfMwkDfsJjdWmQ
 level: Advanced
-tags: ['interviews', ' economics']
+tags: ['interviews', 'economics']
 ---

--- a/collections/_podcasts/NODED.md
+++ b/collections/_podcasts/NODED.md
@@ -4,14 +4,14 @@ code: NODED
 name: Noded Bitcoin Podcast
 hosts: Pierre Rochard and Michael Goldstein
 link: https://noded.org/
-tier: 1
+tier: 2
 ios: https://itunes.apple.com/us/podcast/noded-bitcoin-podcast/id1308074867
 android: ['https://subscribeonandroid.com/noded.org/feed.xml']
 spotify: 
 rss: ['https://noded.org/feed.xml']
-rank: 4
+rank: 6
 twitter: https://twitter.com/NodedPodcast
 youtube: https://www.youtube.com/channel/UC3j-JWXorlfMwkDfsJjdWmQ
-level: 
-tags: ['']
+level: Advanced
+tags: ['interviews', ' economics']
 ---

--- a/collections/_podcasts/OBIT.md
+++ b/collections/_podcasts/OBIT.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/1346f9e8/podcast/rss']
 rank: 16
 twitter: https://twitter.com/princey1976
 youtube: 
+level: Beginner
+tags: ['non-technical', ' entertainment']
 ---

--- a/collections/_podcasts/OBIT.md
+++ b/collections/_podcasts/OBIT.md
@@ -13,5 +13,5 @@ rank: 16
 twitter: https://twitter.com/princey1976
 youtube: 
 level: Beginner
-tags: ['non-technical', ' entertainment']
+tags: ['interviews', ' entertainment']
 ---

--- a/collections/_podcasts/OBIT.md
+++ b/collections/_podcasts/OBIT.md
@@ -13,5 +13,5 @@ rank: 16
 twitter: https://twitter.com/princey1976
 youtube: 
 level: Beginner
-tags: ['interviews', ' entertainment']
+tags: ['interviews', 'entertainment']
 ---

--- a/collections/_podcasts/OTB.md
+++ b/collections/_podcasts/OTB.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/us/podcast/on-the-brink-with-castle-island/id148
 android: ['https://subscribeonandroid.com/castleisland.libsyn.com/rss']
 spotify: https://open.spotify.com/show/47aw3C5brBfL8pCIw8LrQL?si=FXzVA5LoRYyTnsLfPebhkw
 rss: ['https://castleisland.libsyn.com/rss']
-rank: 27
+rank: 24
 twitter: https://twitter.com/OnTheBrinkCIV
 youtube: 
 level: Intermediate
-tags: ['non-technical', ' macro', ' industry']
+tags: ['economics', ' industry']
 ---

--- a/collections/_podcasts/OTB.md
+++ b/collections/_podcasts/OTB.md
@@ -12,4 +12,6 @@ rss: ['https://castleisland.libsyn.com/rss']
 rank: 27
 twitter: https://twitter.com/OnTheBrinkCIV
 youtube: 
+level: Intermediate
+tags: ['non-technical', ' macro', ' industry']
 ---

--- a/collections/_podcasts/OTB.md
+++ b/collections/_podcasts/OTB.md
@@ -13,5 +13,5 @@ rank: 24
 twitter: https://twitter.com/OnTheBrinkCIV
 youtube: 
 level: Intermediate
-tags: ['economics', ' industry']
+tags: ['economics', 'industry']
 ---

--- a/collections/_podcasts/PLEB.md
+++ b/collections/_podcasts/PLEB.md
@@ -4,12 +4,12 @@ code: PLEB
 name: Bitcoin Pleb Talk
 hosts: Saint Bitcoin
 link: https://anchor.fm/saintbitcoin/
-tier: 4
+tier: 0
 ios: https://podcasts.apple.com/us/podcast/bitcoin-pleb-talk-podcast/id1481505187
 android: ['https://subscribeonandroid.com/anchor.fm/s/e3f8794/podcast/rss']
 spotify: https://open.spotify.com/show/3fbBVmIJaXvUs9WWC384s8
 rss: ['https://anchor.fm/s/e3f8794/podcast/rss']
-rank: 28
+rank: 
 twitter: https://twitter.com/btcplebtalk
 youtube: https://www.youtube.com/channel/UChnXfqAcrLHi5lsU0_72-mg
 level: 

--- a/collections/_podcasts/PLEB.md
+++ b/collections/_podcasts/PLEB.md
@@ -4,14 +4,14 @@ code: PLEB
 name: Bitcoin Pleb Talk
 hosts: Saint Bitcoin
 link: https://anchor.fm/saintbitcoin/
-tier: 3
+tier: 4
 ios: https://podcasts.apple.com/us/podcast/bitcoin-pleb-talk-podcast/id1481505187
 android: ['https://subscribeonandroid.com/anchor.fm/s/e3f8794/podcast/rss']
 spotify: https://open.spotify.com/show/3fbBVmIJaXvUs9WWC384s8
 rss: ['https://anchor.fm/s/e3f8794/podcast/rss']
-rank: 21
+rank: 28
 twitter: https://twitter.com/btcplebtalk
 youtube: https://www.youtube.com/channel/UChnXfqAcrLHi5lsU0_72-mg
 level: 
-tags: ['']
+tags: ['inactive']
 ---

--- a/collections/_podcasts/PLEB.md
+++ b/collections/_podcasts/PLEB.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/e3f8794/podcast/rss']
 rank: 21
 twitter: https://twitter.com/btcplebtalk
 youtube: https://www.youtube.com/channel/UChnXfqAcrLHi5lsU0_72-mg
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/POV.md
+++ b/collections/_podcasts/POV.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/us/podcast/pov-crypto-podcast-your-crypto-echo-c
 android: ['https://subscribeonandroid.com/povcryptopod.libsyn.com/rss']
 spotify: https://open.spotify.com/episode/6xCce78RFTQOqOsKzdiYZ5?si=pOPvtOYaQsiOdRNne7EDGw
 rss: ['http://povcryptopod.btc.libsynpro.com/rss']
-rank: 24
+rank: 22
 twitter: https://twitter.com/POVCryptoPod
 youtube: https://www.youtube.com/channel/UC6KH0zR25FufHeMexvGq8tQ
-level: 
-tags: ['']
+level: Advanced
+tags: ['shitcoinery']
 ---

--- a/collections/_podcasts/POV.md
+++ b/collections/_podcasts/POV.md
@@ -12,4 +12,6 @@ rss: ['http://povcryptopod.btc.libsynpro.com/rss']
 rank: 24
 twitter: https://twitter.com/POVCryptoPod
 youtube: https://www.youtube.com/channel/UC6KH0zR25FufHeMexvGq8tQ
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/RR.md
+++ b/collections/_podcasts/RR.md
@@ -12,4 +12,6 @@ rss: ['https://feeds.buzzsprout.com/263522.rss']
 rank: 23
 twitter: https://twitter.com/reckless_review
 youtube: 
+level: Advanced
+tags: ['technical', ' entertainment', ' community']
 ---

--- a/collections/_podcasts/RR.md
+++ b/collections/_podcasts/RR.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/il/podcast/reckless-review/id1454950911
 android: ['https://subscribeonandroid.com/feeds.buzzsprout.com/263522.rss']
 spotify: https://open.spotify.com/show/2dD3BnR6obGdgIqlLZ1mRZ
 rss: ['https://feeds.buzzsprout.com/263522.rss']
-rank: 23
+rank: 21
 twitter: https://twitter.com/reckless_review
 youtube: 
 level: Advanced
-tags: ['technical', ' entertainment', ' community']
+tags: ['entertainment', ' technical']
 ---

--- a/collections/_podcasts/RR.md
+++ b/collections/_podcasts/RR.md
@@ -13,5 +13,5 @@ rank: 21
 twitter: https://twitter.com/reckless_review
 youtube: 
 level: Advanced
-tags: ['entertainment', ' technical']
+tags: ['entertainment', 'technical']
 ---

--- a/collections/_podcasts/SLP.md
+++ b/collections/_podcasts/SLP.md
@@ -13,5 +13,5 @@ rank: 2
 twitter: https://twitter.com/stephanlivera
 youtube: https://www.youtube.com/channel/UCDqPIrJSzHyyJpmH6wnxVxA
 level: Advanced
-tags: ['technical', ' economics', ' interviews']
+tags: ['technical', 'economics', 'interviews']
 ---

--- a/collections/_podcasts/SLP.md
+++ b/collections/_podcasts/SLP.md
@@ -13,5 +13,5 @@ rank: 2
 twitter: https://twitter.com/stephanlivera
 youtube: https://www.youtube.com/channel/UCDqPIrJSzHyyJpmH6wnxVxA
 level: Advanced
-tags: ['technical', ' macro']
+tags: ['technical', ' economics', ' interviews']
 ---

--- a/collections/_podcasts/SLP.md
+++ b/collections/_podcasts/SLP.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/7d083a4/podcast/rss']
 rank: 2
 twitter: https://twitter.com/stephanlivera
 youtube: https://www.youtube.com/channel/UCDqPIrJSzHyyJpmH6wnxVxA
+level: Advanced
+tags: ['technical', ' macro']
 ---

--- a/collections/_podcasts/SSL.md
+++ b/collections/_podcasts/SSL.md
@@ -12,6 +12,6 @@ rss: ['https://feeds.simplecast.com/Z1tu2Hds']
 rank: 7
 twitter: https://twitter.com/swanbitcoin
 youtube: https://www.youtube.com/channel/UCl4takhOQtiyprismCPsa2Q
-level: 
-tags: ['']
+level: Intermediate
+tags: ['roundtable']
 ---

--- a/collections/_podcasts/SSL.md
+++ b/collections/_podcasts/SSL.md
@@ -12,4 +12,6 @@ rss: ['https://feeds.simplecast.com/Z1tu2Hds']
 rank: 7
 twitter: https://twitter.com/swanbitcoin
 youtube: https://www.youtube.com/channel/UCl4takhOQtiyprismCPsa2Q
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/TBS.md
+++ b/collections/_podcasts/TBS.md
@@ -12,4 +12,6 @@ rss: ['https://www.spreaker.com/show/3478385/episodes/feed']
 rank: 8
 twitter: https://twitter.com/saifedean
 youtube: 
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/TBS.md
+++ b/collections/_podcasts/TBS.md
@@ -13,5 +13,5 @@ rank: 8
 twitter: https://twitter.com/saifedean
 youtube: 
 level: Advanced
-tags: ['economics', ' lectures']
+tags: ['economics', 'lectures']
 ---

--- a/collections/_podcasts/TBS.md
+++ b/collections/_podcasts/TBS.md
@@ -12,6 +12,6 @@ rss: ['https://www.spreaker.com/show/3478385/episodes/feed']
 rank: 8
 twitter: https://twitter.com/saifedean
 youtube: 
-level: 
-tags: ['']
+level: Advanced
+tags: ['economics', ' lectures']
 ---

--- a/collections/_podcasts/TCP.md
+++ b/collections/_podcasts/TCP.md
@@ -12,4 +12,6 @@ rss: ['https://podcast.chaincode.com/atom.xml']
 rank: 28
 twitter: https://twitter.com/chaincodelabs
 youtube: https://www.youtube.com/channel/UC9OcX1kIjsowRRZzl8tD27w
+level: 
+tags: ['']
 ---

--- a/collections/_podcasts/TCP.md
+++ b/collections/_podcasts/TCP.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/us/podcast/the-chaincode-podcast/id1496858178
 android: ['https://subscribeonandroid.com/anchor.fm/s/12fe0620/podcast/rss']
 spotify: https://open.spotify.com/show/2wvFLZ2dPLpvNBBnUR4KqW
 rss: ['https://podcast.chaincode.com/atom.xml']
-rank: 28
+rank: 25
 twitter: https://twitter.com/chaincodelabs
 youtube: https://www.youtube.com/channel/UC9OcX1kIjsowRRZzl8tD27w
-level: 
-tags: ['']
+level: Advanced
+tags: ['technical']
 ---

--- a/collections/_podcasts/TFTC.md
+++ b/collections/_podcasts/TFTC.md
@@ -12,4 +12,6 @@ rss: ['https://anchor.fm/s/558f520/podcast/rss']
 rank: 1
 twitter: https://twitter.com/tftc21
 youtube: https://www.youtube.com/tftc21
+level: Intermediate
+tags: ['community', ' entertainment']
 ---

--- a/collections/_podcasts/TFTC.md
+++ b/collections/_podcasts/TFTC.md
@@ -13,5 +13,5 @@ rank: 1
 twitter: https://twitter.com/tftc21
 youtube: https://www.youtube.com/tftc21
 level: Intermediate
-tags: ['community', ' entertainment']
+tags: ['entertainment', ' interviews', ' news']
 ---

--- a/collections/_podcasts/TFTC.md
+++ b/collections/_podcasts/TFTC.md
@@ -13,5 +13,5 @@ rank: 1
 twitter: https://twitter.com/tftc21
 youtube: https://www.youtube.com/tftc21
 level: Intermediate
-tags: ['entertainment', ' interviews', ' news']
+tags: ['entertainment', 'interviews', 'news']
 ---

--- a/collections/_podcasts/UHPC.md
+++ b/collections/_podcasts/UHPC.md
@@ -12,4 +12,6 @@ rss: ['https://www.spreaker.com/show/3478708/episodes/feed']
 rank: 19
 twitter: https://twitter.com/UnhashedPodcast
 youtube: 
+level: Advanced
+tags: ['technical', ' community', ' entertainment']
 ---

--- a/collections/_podcasts/UHPC.md
+++ b/collections/_podcasts/UHPC.md
@@ -13,5 +13,5 @@ rank: 19
 twitter: https://twitter.com/UnhashedPodcast
 youtube: 
 level: Advanced
-tags: ['technical', ' community', ' entertainment']
+tags: ['technical', 'community', 'entertainment']
 ---

--- a/collections/_podcasts/VWS.md
+++ b/collections/_podcasts/VWS.md
@@ -1,0 +1,17 @@
+---
+layout: page
+code: VWS
+name: The Van Wirdum Sjorsnado
+hosts: Aaron van Wirdum and Sjors Provoost
+link: https://bitcoinmagazine.com/
+tier: 2
+ios: https://podcasts.apple.com/us/podcast/bitcoin-magazine/id1459884105
+android: ['https://subscribeonandroid.com/bitcoinmagazine.btc.libsynpro.com/rss']
+spotify: https://open.spotify.com/show/1IxBiqXrUwWUgwiQwKWwxk
+rss: ['http://bitcoinmagazine.btc.libsynpro.com/rss']
+rank: 17
+twitter: https://twitter.com/AaronvanW
+youtube: https://www.youtube.com/playlist?list=PLe0djdakvnFZkrHHLVIxwaB0sz9zKRp12
+level: Advanced
+tags: ['technical']
+---

--- a/collections/_podcasts/WBD.md
+++ b/collections/_podcasts/WBD.md
@@ -13,5 +13,5 @@ rank: 10
 twitter: https://twitter.com/WhatBitcoinDid
 youtube: https://www.youtube.com/whatbitcoindid
 level: Beginner
-tags: ['interviews', ' roundtable']
+tags: ['interviews', 'roundtable']
 ---

--- a/collections/_podcasts/WBD.md
+++ b/collections/_podcasts/WBD.md
@@ -13,5 +13,5 @@ rank: 10
 twitter: https://twitter.com/WhatBitcoinDid
 youtube: https://www.youtube.com/whatbitcoindid
 level: Beginner
-tags: ['community', ' non-technical']
+tags: ['interviews', ' roundtable']
 ---

--- a/collections/_podcasts/WBD.md
+++ b/collections/_podcasts/WBD.md
@@ -12,4 +12,6 @@ rss: ['https://www.whatbitcoindid.com/podcast?format=RSS']
 rank: 10
 twitter: https://twitter.com/WhatBitcoinDid
 youtube: https://www.youtube.com/whatbitcoindid
+level: Beginner
+tags: ['community', ' non-technical']
 ---

--- a/index.md
+++ b/index.md
@@ -404,17 +404,9 @@ I consider the following podcasts the best in the space:
 
 {% include podcasts.html tier="1" %}
 
-Although I try to listen to every Bitcoin podcast under the sun, it is simply an
-unsurmountable feat due to the sheer volume of content. The following podcasts
-are excellent as well:
+[View all podcasts »][podcasts]
 
-{% include podcasts.html tier="2" %}
-
-The line between the best and the rest is quite arbitrary, but I felt like one
-very long list might not be as useful as separate lists, however arbitrary the
-distinction. I enjoy or have enjoyed these podcasts as well:
-
-{% include podcasts.html tier="3" %}
+[podcasts]: {{ '/podcasts' | absolute_url }}
 
 #### Noteworthy Podcast Series
 

--- a/podcasts.md
+++ b/podcasts.md
@@ -5,9 +5,19 @@ image: /assets/images/bitcoin-resources-twitter-cover.png
 description: Curated Bitcoin podcasts and episodes.
 ---
 
-{% include podcasts.html tier="1" %}
-{% include podcasts.html tier="2" %}
-{% include podcasts.html tier="3" %}
+### Beginner
+
+{% include podcasts.html level="Beginner" %}
+
+### Intermediate
+
+{% include podcasts.html level="Intermediate" %}
+
+### Advanced
+
+{% include podcasts.html level="Advanced" %}
+
+
 
 ### Archive
 

--- a/podcasts.md
+++ b/podcasts.md
@@ -23,4 +23,4 @@ description: Curated Bitcoin podcasts and episodes.
 
 The following podcasts are not active anymore.
 
-{% include podcasts.html tier="4" %}
+{% include podcasts.html tier="0" %}

--- a/podcasts.md
+++ b/podcasts.md
@@ -17,7 +17,13 @@ description: Curated Bitcoin podcasts and episodes.
 
 {% include podcasts.html level="Advanced" %}
 
+### Specialized
 
+As Bitcoin grows, more specialization is to be expected. The following podcasts
+focus on one specific aspect of Bitcoin, such as the Lightning Network or
+mining.
+
+{% include podcasts.html level="Specialized" %}
 
 ### Archive
 

--- a/podcasts.md
+++ b/podcasts.md
@@ -5,6 +5,13 @@ image: /assets/images/bitcoin-resources-twitter-cover.png
 description: Curated Bitcoin podcasts and episodes.
 ---
 
+The following podcasts are roughly grouped into
+[beginner](#beginner),
+[intermediate](#intermediate), and
+[advanced](#advanced).
+There is also a "[specialized](#specialized)" category for podcasts that
+focus on one narrow aspect of Bitcoin, and an [archive](#archive) for inactive shows.
+
 ### Beginner
 
 {% include podcasts.html level="Beginner" %}

--- a/podcasts.md
+++ b/podcasts.md
@@ -8,3 +8,9 @@ description: Curated Bitcoin podcasts and episodes.
 {% include podcasts.html tier="1" %}
 {% include podcasts.html tier="2" %}
 {% include podcasts.html tier="3" %}
+
+### Archive
+
+The following podcasts are not active anymore.
+
+{% include podcasts.html tier="4" %}

--- a/podcasts.md
+++ b/podcasts.md
@@ -1,0 +1,10 @@
+---
+layout: resources
+title: Podcasts
+image: /assets/images/bitcoin-resources-twitter-cover.png
+description: Curated Bitcoin podcasts and episodes.
+---
+
+{% include podcasts.html tier="1" %}
+{% include podcasts.html tier="2" %}
+{% include podcasts.html tier="3" %}

--- a/scripts/spreadsheet_to_resource_mds/update_pods.py
+++ b/scripts/spreadsheet_to_resource_mds/update_pods.py
@@ -33,7 +33,7 @@ for row in sodes.get_all_values():
     pod_twitter = row[10].lstrip().rstrip()
     pod_youtube = row[11].lstrip().rstrip() if row[11] != '' else EMPTY
     pod_level = row[12].lstrip().rstrip()
-    pod_tags = row[13].lstrip().rstrip().split(',')
+    pod_tags = row[13].lstrip().rstrip().split(', ')
 
     md_file_path = '../../collections/_podcasts/' + pod_code + '.md'
     if md_file_path == "":

--- a/scripts/spreadsheet_to_resource_mds/update_pods.py
+++ b/scripts/spreadsheet_to_resource_mds/update_pods.py
@@ -32,6 +32,8 @@ for row in sodes.get_all_values():
     pod_rank = row[9]
     pod_twitter = row[10].lstrip().rstrip()
     pod_youtube = row[11].lstrip().rstrip() if row[11] != '' else EMPTY
+    pod_level = row[12].lstrip().rstrip()
+    pod_tags = row[13].lstrip().rstrip().split(',')
 
     md_file_path = '../../collections/_podcasts/' + pod_code + '.md'
     if md_file_path == "":
@@ -52,6 +54,8 @@ for row in sodes.get_all_values():
                 f"rank: {pod_rank}\n"
                 f"twitter: {pod_twitter}\n"
                 f"youtube: {pod_youtube}\n"
+                f"level: {pod_level}\n"
+                f"tags: {pod_tags}\n"
                 f"---\n")
 
     with open(md_file_path, 'w') as f:


### PR DESCRIPTION
### General changes:

* updated podcast list
* moved long podcast list to separate `/podcasts` page
* introduced "levels": beginner, intermediate, advanced
* added "specialized" category and podcast archive (for inactive show)
* added tag support

### Content changes:

Added Podcasts:
* Added HASHR8 podcast
* Added Lightning Junkies podcast
* Added The Van Wirdum Sjorsnado