### PR TITLE
Update wall.md; JBP's link

### DIFF
--- a/books/wall.md
+++ b/books/wall.md
@@ -14,7 +14,7 @@ description: Curated Bitcoin books.
 For you CTRL+F freaks.
 
 Also make sure to check out [bitcoiner books](https://www.bitcoinerbooks.com/)
-and [JBP's list of great books](https://www.jordanbpeterson.com/great-books/).
+and [JBP's list of recommended literature](https://www.jordanbpeterson.com/books/#:~:text=RECOMMENDED).
 
 {% include books-list.html %}
 


### PR DESCRIPTION
The /great-books/ link is updated and shows an error page. 

- Changed the link url to /books/
- Changed the text to be in line with JBP's text on his site ( 'recommended literature')