### PR TITLE
Add Fathom script

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -88,3 +88,5 @@
     ga('send', 'pageview');
   </script>
 {% endif %}
+
+<script src="https://cdn.usefathom.com/script.js" data-site="KHMCAHKM" defer></script>


### PR DESCRIPTION
Adds the Fathom to the website head template. The script is loaded from the Fathom CDN.