### PR TITLE
fix: replace Telegram link with Matrix in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ is to provide a well curated list of high quality bitcoin-only resources.
 ### Before you start
 
 * Make yourself familiar with the [existing content](https://bitcoin-resources.com)
-* Join our [Telegram chat group](https://t.me/BitcoinResourcesCom)
+* Join our [Matrix chat](https://matrix.to/#/#bitcoin-resources:matrix.dergigi.com)
 * Have a look at the [existing issues](https://github.com/bitcoin-resources/bitcoin-resources.github.io/issues)
 
 ### Agreeing on a change


### PR DESCRIPTION
Replaces the dead Telegram chat group link with the Matrix room. Closes #613.