### PR TITLE
fix: update broken links in podcast entries

### DIFF
--- a/collections/_podcasts/BAND.md
+++ b/collections/_podcasts/BAND.md
@@ -3,7 +3,7 @@ layout: page
 code: BAND
 name: Bitcoin and...
 hosts: David Bennet
-link: http://bitcoinand.net/bio.html
+link: https://davidbennett.me/
 tier: 2
 ios: https://podcasts.apple.com/us/podcast/bitcoin-and/id1438789088
 android: ['https://subscribeonandroid.com/feeds.soundcloud.com/users/soundcloud:users:108074218/sounds.rss']

--- a/collections/_podcasts/DD.md
+++ b/collections/_podcasts/DD.md
@@ -3,12 +3,12 @@ layout: page
 code: DD
 name: Dirtcoin Diaries
 hosts: Bitcoin Enemies
-link: https://meetup.bitcoinenemies.com/@dirtcoin
+link: 
 tier: 0
 ios: 
-android: ['https://subscribeonandroid.com/meetup.bitcoinenemies.com/@dirtcoin/feed.xml']
+android: []
 spotify: 
-rss: ['https://meetup.bitcoinenemies.com/@dirtcoin/feed.xml']
+rss: []
 rank: 
 twitter: https://twitter.com/bitcoinenemies
 youtube: 

--- a/collections/_podcasts/FTLOB.md
+++ b/collections/_podcasts/FTLOB.md
@@ -3,12 +3,12 @@ layout: page
 code: FTLOB
 name: For the Love of Bitcoin
 hosts: Bitcoin Granny, Bitcoin Mechanic & Bitcoin Sensei
-link: https://fortheloveofbitcoin.buzzsprout.com/1655380
+link: 
 tier: 2
-ios: https://podcasts.apple.com/us/podcast/for-the-love-of-bitcoin/id1551683632
-android: ['https://subscribeonandroid.com/feeds.buzzsprout.com/1655380.rss']
-spotify: https://open.spotify.com/show/20wXgrsYicdzxPJloDpVI4
-rss: ['https://feeds.buzzsprout.com/1655380.rss']
+ios: 
+android: []
+spotify: 
+rss: []
 rank: 22
 twitter: 
 youtube: https://www.youtube.com/channel/UC9-9d1j_8zZzYum3FAsW5yQ

--- a/collections/_podcasts/KRS.md
+++ b/collections/_podcasts/KRS.md
@@ -3,7 +3,7 @@ layout: page
 code: KRS
 name: The Kevin Rooke Show
 hosts: Kevin Rooke
-link: https://www.kevinrooke.com/podcast
+link: https://www.stacksats.how/podcast
 tier: 2
 ios: https://podcasts.apple.com/podcast/id1592522623
 android: ['https://subscribeonandroid.com/anchor.fm/s/71a8cc78/podcast/rss']

--- a/collections/_podcasts/OP.md
+++ b/collections/_podcasts/OP.md
@@ -3,12 +3,12 @@ layout: page
 code: OP
 name: Orange Pill Podcast
 hosts: Max Keiser and Stacy Herbert
-link: https://orangepill.buzzsprout.com/
+link: 
 tier: 2
-ios: https://podcasts.apple.com/us/podcast/orange-pill-podcast/id1527940173
-android: ['https://subscribeonandroid.com/feeds.buzzsprout.com/1263314.rss']
-spotify: https://open.spotify.com/show/1qosvsTT69uM1GAhA0vUY2
-rss: ['https://feeds.buzzsprout.com/1263314.rss']
+ios: 
+android: []
+spotify: 
+rss: []
 rank: 19
 twitter: https://twitter.com/orangepillpod
 youtube: https://www.youtube.com/playlist?list=PLTOegK5LOKEpRlxadVNWehZfBJk97sFw5

--- a/collections/_podcasts/OTB.md
+++ b/collections/_podcasts/OTB.md
@@ -3,7 +3,7 @@ layout: page
 code: OTB
 name: On The Brink
 hosts: Nic Carter and Matt Walsh
-link: https://onthebrink-podcast.com/
+link: https://www.castleisland.vc/
 tier: 3
 ios: https://podcasts.apple.com/us/podcast/on-the-brink-with-castle-island/id1480586463
 android: ['https://subscribeonandroid.com/castleisland.libsyn.com/rss']

--- a/collections/_podcasts/SBTV.md
+++ b/collections/_podcasts/SBTV.md
@@ -3,7 +3,7 @@ layout: page
 code: SBTV
 name: Simply Bitcoin TV
 hosts: Coinicarus and Nico
-link: https://simplybitcoin.tv/
+link: https://www.simplybitcoin.com/
 tier: 0
 ios: https://podcasts.apple.com/us/podcast/simply-bitcoin/id1596756460
 android: ['http://subscribeonandroid.com/anchor.fm/s/717a2198/podcast/rss']

--- a/collections/_podcasts/TFTC.md
+++ b/collections/_podcasts/TFTC.md
@@ -3,7 +3,7 @@ layout: page
 code: TFTC
 name: Tales From The Crypt
 hosts: Marty Bent with RHR co-host Matt Odell
-link: https://tftc.io/podcasts/
+link: https://tftc.io/
 tier: 1
 ios: https://podcasts.apple.com/us/podcast/tales-from-the-crypt/id1292381204
 android: ['https://subscribeonandroid.com/anchor.fm/s/558f520/podcast/rss']


### PR DESCRIPTION
Fixes broken links across podcast entries. Several podcasts have moved to new URLs, others appear to be genuinely defunct with all links dead.

- [x] `BAND.md` — `link`: bitcoinand.net dead, updated to `davidbennett.me`
- [x] `DD.md` — `link`/`android`/`rss`: bitcoinenemies.com dead, cleared (podcast defunct)
- [x] `FTLOB.md` — all links dead (buzzsprout, Apple, Spotify), cleared (podcast defunct)
- [x] `KRS.md` — `link`: kevinrooke.com dead, updated to `stacksats.how/podcast`
- [x] `OP.md` — all links dead (buzzsprout, Apple, Spotify), cleared (podcast defunct)
- [x] `OTB.md` — `link`: onthebrink-podcast.com dead, updated to `castleisland.vc`
- [x] `SBTV.md` — `link`: simplybitcoin.tv dead, updated to `simplybitcoin.com`
- [x] `TFTC.md` — `link`: tftc.io/podcasts/ 404, updated to `tftc.io`
- [ ] `LTB.md` — letstalkbitcoin.com 404, no replacement found
- [ ] `UHPC.md` — unhashedpodcast.com unreachable, no replacement found
- [ ] `LJ.md` — lightningjunkies.net unreachable, no replacement found
- [ ] `THLI.md` — thrillerlightning.com unreachable, no replacement found
- [ ] `ABNP.md` — podbean feed dead, no replacement found
- [ ] `CV.md` — cryptovoices.com unreachable, no replacement found
- [ ] `TBS.md` — spreaker feed dead, no replacement found
- [ ] `WBP.md` — whybitcoinpodcast.com unreachable, no replacement found
- [ ] `RASS.md` — mcfloogle.com dead, no replacement found
- [ ] `BIP.md` — bitcoininfinitypodcast.com unreachable, no replacement found
- [ ] `UXUI.md` — bitcoinopuxui.com dead, no replacement found