### PR TITLE
fix: update broken links in episodes, series, and curations

### DIFF
--- a/collections/_curations/bitcoin-resources.md
+++ b/collections/_curations/bitcoin-resources.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Bitcoin Resources
-link: https://www.mcfloogle.com/bitcoin-resources/
+link:
 author: Rollo McFloogle
 type: curation
 star: 

--- a/collections/_curations/featured-episodesof-bitcoin-audible.md
+++ b/collections/_curations/featured-episodesof-bitcoin-audible.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Featured Episodes of Bitcoin Audible
-link: https://sourcecrypto.pub/blog/thecryptoconomy-podcast-deep-dive/
+link:
 author: Infominer
 type: curation
 star: 

--- a/collections/_curations/nicks-learning-resources.md
+++ b/collections/_curations/nicks-learning-resources.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Nick's Learning Resources
-link: https://nickbeaird.com/bitcoin
+link:
 author: Nick Beaird
 type: curation
 star: 

--- a/collections/_episodes/JBP440.md
+++ b/collections/_episodes/JBP440.md
@@ -7,6 +7,6 @@ hosts: Jordan B. Peterson
 date: Aug 9, 2021
 guest: John Vallis & Richard James & Gigi Der & Robert Breedlove
 lesson: ['1']
-link: https://www.jordanbpeterson.com/podcast/s4e40/
+link: https://web.archive.org/web/2023/https://www.jordanbpeterson.com/podcast/s4e40/
 fav: true
 ---

--- a/collections/_episodes/WBD183.md
+++ b/collections/_episodes/WBD183.md
@@ -7,6 +7,6 @@ hosts: Peter McCormack
 date: Jan 7, 2020
 guest: Parker Lewis
 lesson: ['11']
-link: https://www.whatbitcoindid.com/podcast/the-beginners-guide-to-bitcoin-part-2-what-is-money-with-parker-lewis
+link: https://web.archive.org/web/2023/https://www.whatbitcoindid.com/podcast/the-beginners-guide-to-bitcoin-part-2-what-is-money-with-parker-lewis
 fav: 
 ---

--- a/collections/_episodes/WBD362.md
+++ b/collections/_episodes/WBD362.md
@@ -7,6 +7,6 @@ hosts: Peter McCormack
 date: Jun 18, 2021
 guest: Jack Mallers
 lesson: ['21']
-link: https://www.whatbitcoindid.com/podcast/el-salvador-the-whole-story
+link: https://web.archive.org/web/2023/https://www.whatbitcoindid.com/podcast/el-salvador-the-whole-story
 fav: 
 ---

--- a/collections/_episodes/WBD49.md
+++ b/collections/_episodes/WBD49.md
@@ -7,6 +7,6 @@ hosts: Peter McCormack
 date: Nov 21, 2018
 guest: Peter Van Valkenburg
 lesson: ['3']
-link: https://www.whatbitcoindid.com/podcast/coin-centers-peter-van-valkenburg-on-preserving-the-freedom-to-innovate-with-public-blockchains
+link: https://web.archive.org/web/2023/https://www.whatbitcoindid.com/podcast/coin-centers-peter-van-valkenburg-on-preserving-the-freedom-to-innovate-with-public-blockchains
 fav: 
 ---

--- a/collections/_series/bitcoin-astronomy.md
+++ b/collections/_series/bitcoin-astronomy.md
@@ -4,7 +4,7 @@ author: Dhruv Bansal
 authorurl: https://twitter.com/dhruvbansal
 title: Bitcoin Astronomy
 date: Sep 13, 2019
-landing: https://unchained.com/blog/category/bitcoin-astronomy/
+landing: https://unchained.com/blog-tag/bitcoin-astronomy
 mirror:
 archive: https://archive.is/X9sms
 ---

--- a/collections/_series/bittorrent-lessons-for-crypto.md
+++ b/collections/_series/bittorrent-lessons-for-crypto.md
@@ -5,6 +5,6 @@ authorurl: https://twitter.com/simonhmorris
 title: BitTorrent Lessons for Crypto
 date: December 25, 2018
 landing: https://medium.com/@simonhmorris/why-bittorrent-mattered-bittorrent-lessons-for-crypto-1-of-4-fa3c6fcef488
-mirror: https://bitcoinaudible.com/why-bittorrent-mattered-lessons-for-crypto-1-of-4/
+mirror:
 archive: https://archive.ph/EWYFL
 ---


### PR DESCRIPTION
Fixes broken links across episode, series, and curation entries. WBD and JBP episode links point to Wayback Machine archives since the originals are gone. Series landing pages updated. Dead curation links cleared where no replacement exists.

- [x] `WBD183.md` — `link`: whatbitcoindid.com 404, pointed to Wayback Machine
- [x] `WBD49.md` — `link`: whatbitcoindid.com 404, pointed to Wayback Machine
- [x] `WBD362.md` — `link`: whatbitcoindid.com 404, pointed to Wayback Machine
- [x] `JBP440.md` — `link`: jordanbpeterson.com 404, pointed to Wayback Machine
- [x] `bitcoin-astronomy.md` — `landing`: unchained.com restructured, updated to `unchained.com/blog-tag/bitcoin-astronomy`
- [x] `bittorrent-lessons-for-crypto.md` — `mirror`: bitcoinaudible.com 404, cleared
- [x] `featured-episodesof-bitcoin-audible.md` — `link`: sourcecrypto.pub 404, cleared
- [x] `nicks-learning-resources.md` — `link`: nickbeaird.com 404, cleared
- [x] `bitcoin-resources.md` — `link`: mcfloogle.com 406, cleared
- [ ] `HF75.md` — `link`: hiddenforces.io 404, no Wayback snapshot available
- [ ] `bitcoin-intro.md` — `link`: bitcoin-intro.com unreachable, may be temporary
- [ ] `bitcoin-only.md` — `link`: bitcoin-only.com was unreachable during scan but is live now, left unchanged
- [ ] `timechain.md` — `link`: timechaindemo.io unreachable, may be temporary