### PR TITLE
Add article: Mises: The Original Toxic Maximalist

### DIFF
--- a/collections/_articles/mises-the-original-toxic-maximalist.md
+++ b/collections/_articles/mises-the-original-toxic-maximalist.md
@@ -1,0 +1,17 @@
+---
+layout: page-article
+author: Michael Goldstein
+title: "Mises: The Original Toxic Maximalist"
+link: https://bitstein.substack.com/p/mises-the-original-toxic-maximalist
+category: Bitcoin's Identity
+date: Dec 10, 2022
+lesson: 
+audio: 
+audio2: 
+audio3: 
+star: 
+archive: https://web.archive.org/web/20250114025252/https://bitstein.substack.com/p/mises-the-original-toxic-maximalist
+series: 
+seriesnr: 
+quote: "My recommendation is to commit oneself to the truth and the promotion of the truth, and judge the effectiveness of rhetoric on its long term influence rather than short term popularity."
+---


### PR DESCRIPTION
Adds Michael Goldstein's (Bitstein) article "Mises: The Original Toxic Maximalist" to the articles collection, filed under `Bitcoin's Identity`. The article draws parallels between Mises's unwavering commitment to sound money and free markets and the Bitcoin maximalist stance, arguing that monetary competition naturally tends toward a single winner and that compromising on decentralization leads to shitcoining.

- Source: bitstein.substack.com, published Dec 10, 2022
- Archive link included (Wayback Machine)
- Closes #387