### PR TITLE
Add Bitcoin Optech Podcast

### DIFF
--- a/collections/_podcasts/BOT.md
+++ b/collections/_podcasts/BOT.md
@@ -1,0 +1,17 @@
+---
+layout: page
+code: BOT
+name: Bitcoin Optech Podcast
+hosts: Mark Erhardt, Mike Schmidt
+link: https://bitcoinops.org/en/podcast/
+tier: 1
+ios: https://podcasts.apple.com/us/podcast/bitcoin-optech-podcast/id1674626983
+android: ['https://anchor.fm/s/d9918154/podcast/rss']
+spotify: https://open.spotify.com/show/5UnB50h4O1jKaq5AyfN9Qo
+rss: ['https://anchor.fm/s/d9918154/podcast/rss']
+rank: 5
+twitter: https://twitter.com/bitcoinoptech
+youtube:
+level: Advanced
+tags: ['technical', 'development', 'protocol']
+---

--- a/collections/_podcasts/BOT.md
+++ b/collections/_podcasts/BOT.md
@@ -9,9 +9,9 @@ ios: https://podcasts.apple.com/us/podcast/bitcoin-optech-podcast/id1674626983
 android: ['https://anchor.fm/s/d9918154/podcast/rss']
 spotify: https://open.spotify.com/show/5UnB50h4O1jKaq5AyfN9Qo
 rss: ['https://anchor.fm/s/d9918154/podcast/rss']
-rank: 5
+rank: 5.5
 twitter: https://twitter.com/bitcoinoptech
 youtube:
 level: Advanced
-tags: ['technical', 'development', 'protocol']
+tags: ['technical', 'news', 'lightning']
 ---


### PR DESCRIPTION
Adds the Bitcoin Optech Podcast to the podcasts collection. It is a weekly recap of the Bitcoin Optech newsletter, hosted by Mark "Murch" Erhardt and Mike Schmidt, with deep technical discussions on Bitcoin and Lightning development.

- Podcast code: `BOT`, entry at `collections/_podcasts/BOT.md`
- Links: Apple Podcasts, Spotify, RSS (via Anchor)
- Closes #410
