### PR TITLE
Add learn-bitcoin.md for Bitcoin learning resources

### DIFF
--- a/collections/_curations/learn-bitcoin.md
+++ b/collections/_curations/learn-bitcoin.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Learn Bitcoin
+link: https://www.learnbitcoin.com
+author: LearnBitcoin.com
+type: learn
+star: YES
+order: 43
+---


### PR DESCRIPTION
Adds LearnBitcoin.com — a Bitcoin-only education site (manifesto: "Bitcoin only. No bullshit. Have fun."). 447 glossary entries, 11 deep-dive "rabbit holes", and a guided journey from "what is money?" to running your own node. Content is CC-BY-SA, source at treib-holdings/learnbitcoin-content.

Placed at order: 43 to avoid renumbering existing entries. Happy to slot into the learn cluster at whatever order works.