### PR TITLE
feat: add quote and description for The Blocksize War

### DIFF
--- a/collections/_books/the-blocksize-war.md
+++ b/collections/_books/the-blocksize-war.md
@@ -14,9 +14,9 @@ free_url: https://blog.bitmex.com/the-blocksize-war-chapter-1-first-strike/
 summary_url: https://twitter.com/gladstein/status/1374054823012626432
 rating_order: 8
 lesson: ['4']
-quote: "Bitcoin is really just a vessel for your expectations, hopes, and dreams."
+quote: ""
 audio_url: https://amzn.to/3xN6AhB
 free_audio_url: 
 goodreads_url: 
-description: ""
+description: "Jonathan Bier chronicles the blocksize war that consumed Bitcoin from 2015 to 2017. What looked like a dispute over block limits became a deeper fight over governance, decentralization, and who ultimately sets Bitcoin’s rules. Drawing on front-line reporting and conversations with key participants, the book traces the personalities, proposals, and power plays behind one of the most important battles in Bitcoin history."
 ---

--- a/collections/_books/the-blocksize-war.md
+++ b/collections/_books/the-blocksize-war.md
@@ -14,7 +14,7 @@ free_url: https://blog.bitmex.com/the-blocksize-war-chapter-1-first-strike/
 summary_url: https://twitter.com/gladstein/status/1374054823012626432
 rating_order: 8
 lesson: ['4']
-quote: ""
+quote: "Bitcoin is really just a vessel for your expectations, hopes, and dreams."
 audio_url: https://amzn.to/3xN6AhB
 free_audio_url: 
 goodreads_url: 


### PR DESCRIPTION
Adds both a quote and a description to the `The Blocksize War` entry. The description gives readers clear context on the 2015 to 2017 scaling conflict, and the quote highlights the deeper struggle over competing visions for Bitcoin.
